### PR TITLE
Publish a Homebrew bottle for Xcode 26.6 installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,15 @@ name: release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing release tag to add a Homebrew bottle to
+        required: true
+        type: string
+
+env:
+  SIMSLIM_RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 permissions:
   contents: write
@@ -16,14 +25,47 @@ jobs:
         with:
           go-version: "1.23"
       - name: Build
+        if: github.event_name == 'push'
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          SIMSLIM_VERSION="${SIMSLIM_RELEASE_TAG#v}"
           go test ./...
-          go build -ldflags "-X main.version=${VERSION}" -o simslim .
+          go build -ldflags "-X main.version=${SIMSLIM_VERSION}" -o simslim .
           codesign --force --sign - simslim
-          tar -czf "simslim-${GITHUB_REF_NAME}-macos-arm64.tar.gz" simslim
-          shasum -a 256 "simslim-${GITHUB_REF_NAME}-macos-arm64.tar.gz"
+          tar -czf "simslim-${SIMSLIM_RELEASE_TAG}-macos-arm64.tar.gz" simslim
+          shasum -a 256 "simslim-${SIMSLIM_RELEASE_TAG}-macos-arm64.tar.gz"
+      - name: Build Homebrew bottle
+        run: |
+          SIMSLIM_SOURCE_URL="https://github.com/${GITHUB_REPOSITORY}/archive/refs/tags/${SIMSLIM_RELEASE_TAG}.tar.gz"
+          SIMSLIM_SOURCE_TARBALL="${RUNNER_TEMP}/simslim-source.tar.gz"
+          SIMSLIM_BUILD_TAP="mobai-app/simslim-release"
+
+          curl --fail --location --retry 3 "${SIMSLIM_SOURCE_URL}" --output "${SIMSLIM_SOURCE_TARBALL}"
+          SIMSLIM_SOURCE_SHA256="$(shasum -a 256 "${SIMSLIM_SOURCE_TARBALL}" | cut -d ' ' -f 1)"
+
+          brew tap-new --no-git "${SIMSLIM_BUILD_TAP}"
+          SIMSLIM_FORMULA="$(brew --repository "${SIMSLIM_BUILD_TAP}")/Formula/simslim.rb"
+          mkdir -p "$(dirname "${SIMSLIM_FORMULA}")"
+          sed \
+            -e "s|@SOURCE_URL@|${SIMSLIM_SOURCE_URL}|g" \
+            -e "s|@SOURCE_SHA256@|${SIMSLIM_SOURCE_SHA256}|g" \
+            packaging/homebrew/simslim.rb.in > "${SIMSLIM_FORMULA}"
+
+          brew install --build-bottle "${SIMSLIM_BUILD_TAP}/simslim"
+          brew test "${SIMSLIM_BUILD_TAP}/simslim"
+          brew bottle \
+            --json \
+            --no-rebuild \
+            --root-url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${SIMSLIM_RELEASE_TAG}" \
+            "${SIMSLIM_BUILD_TAP}/simslim"
+
+          # brew uses a double dash locally; custom HTTP bottle URLs use one.
+          for SIMSLIM_BOTTLE in simslim--*.bottle*.tar.gz; do
+            mv "${SIMSLIM_BOTTLE}" "${SIMSLIM_BOTTLE/--/-}"
+          done
       - name: Release
         uses: softprops/action-gh-release@v2
         with:
-          files: simslim-*-macos-arm64.tar.gz
+          tag_name: ${{ env.SIMSLIM_RELEASE_TAG }}
+          files: |
+            simslim-*-macos-arm64.tar.gz
+            simslim-*.bottle*.tar.gz

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ or
 go install github.com/mobai-app/simslim@latest
 ```
 
-macOS only, and you need Xcode's command-line tools, since it drives simulators through `simctl`.
+macOS only, and you need Xcode with an iOS Simulator runtime, since simslim
+drives simulators through `xcrun simctl`.
 
 ## Usage
 

--- a/packaging/homebrew/simslim.rb.in
+++ b/packaging/homebrew/simslim.rb.in
@@ -1,0 +1,19 @@
+class Simslim < Formula
+  desc "Run more iOS simulators on one Mac by disabling unneeded background daemons"
+  homepage "https://github.com/mobai-app/simslim"
+  url "@SOURCE_URL@"
+  sha256 "@SOURCE_SHA256@"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on arch: :arm64
+  depends_on :macos
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/simslim --version")
+  end
+end


### PR DESCRIPTION
## Summary

- build and test a relocatable Homebrew bottle from each tagged source release
- upload the bottle alongside the existing macOS binary asset
- allow an existing tag such as `v0.1.0` to receive a bottle through manual workflow dispatch
- document that simslim needs Xcode plus an iOS Simulator runtime, not the standalone Command Line Tools package

## Why

The tap currently wraps a prebuilt binary tarball in an unbottled formula. Homebrew therefore treats installation as a source build and runs its Command Line Tools minimum-version checks before `install` merely copies the binary. On macOS 26.5.2 with Xcode 26.6 selected, an old standalone CLT 16.2 receipt makes `brew install mobai-app/tap/simslim` abort even though the released binary itself runs correctly with Xcode 26.6.

A cask is not a safe substitute here: the release is ad-hoc signed, so Gatekeeper quarantines and rejects it when installed as a cask. A real Homebrew bottle avoids both problems while retaining checksum verification and normal formula installation.

## Verification

- reproduced the reported Homebrew failure with Xcode 26.6 selected
- ran the released `simslim 0.1.0` binary and enumerated iOS 26.5 simulators successfully
- ran `go test ./...` with Go 1.23.12
- built the formula-equivalent binary with `-trimpath` and the version ldflag
- passed Homebrew formula style checks
- generated a relocatable bottle with the release root URL, verified the release-filename conversion, and poured an equivalent local bottle successfully
- passed actionlint 1.7.12 with ShellCheck 0.11.0 on the updated workflow

## Maintainer follow-up

After merge, manually run the `release` workflow with `tag = v0.1.0`. It will append the bottle asset to the existing release and print the `bottle do` stanza. Copy that stanza into `MobAI-App/homebrew-tap/Formula/simslim.rb` so Homebrew selects the bottle. I did not run or publish the release workflow.