### PR TITLE
Add per-service profiles and preserve system share sheets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,9 +38,13 @@ subpackages. `main.go` is the CLI entry point: it dispatches `os.Args[1]` to a
 
 **The slimming model (the core idea).** `profiles.go` defines `Categories`, an
 allowlist of launchd daemon labels grouped by user-facing feature (siri, search,
-icloud, …). `managedSet()` is the union of every label in `Categories` — **the
-only labels the tool may ever disable or enable.** Anything not in a category is
-never touched. `slim.go`'s `ensure()` boots the device, reads its currently
+icloud, …). `slimmableSet()` is the union of every label in `Categories`.
+`managedSet()` adds each category's `AlwaysEnabled` compatibility services,
+which simslim may only repair back to enabled; these are **the only labels the
+tool may ever disable or enable.** Anything outside those sets is never touched.
+`service_descriptions.go` supplies the short per-daemon explanations shown by
+the GUI; its coverage and length are enforced in `profiles_test.go`.
+`slim.go`'s `ensure()` boots the device, reads its currently
 disabled labels, computes a `delta` against the desired set, and applies the
 changes with `launchctl disable/enable` run inside the simulator via
 `simctl spawn`. The disables are written as persistent launchd overrides, so a
@@ -72,8 +76,8 @@ The app is a thin front end that shells out to that bundled binary.
   a simulator when disabled. `profiles_test.go` holds a `forbiddenLabels` list and
   asserts none appear in any category; if you add labels, keep that test green.
 - **Only managed labels are ever mutated.** `delta()` is scoped to `managedSet()`
-  on both sides — a non-managed label is neither disabled nor re-enabled even if
-  it is already in the wrong state.
+  on both sides. Compatibility labels are omitted from every desired slim state,
+  so they can only be repaired to enabled.
 - **Destructive/management commands resolve the exact UDID first** (`findDevice` /
   `shutdownIfBooted`) so a `simctl` alias like `all` can never fan out a boot,
   erase, delete, or filesystem path across every simulator.
@@ -93,7 +97,7 @@ The app is a thin front end that shells out to that bundled binary.
   machine-readable JSON goes to **stdout**. Under `--json`, suppress the stderr
   chatter so consumers reading a combined stream still get clean JSON.
 - Memory estimates (`ApproxMemoryMB`) are iOS-26.5 clean-boot medians and are
-  **not additive** — don't sum them or present them as guaranteed savings.
+  **not additive**. Every category must have a positive measured estimate.
 
 ## Git
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ drives simulators through `xcrun simctl`.
 The SwiftUI app bundles the CLI and adds:
 
 - Searchable simulator status, disk-size, and live RAM columns.
-- Multi-select service profiles with progress and reversible restore.
+- Searchable service profiles with per-daemon controls and purpose summaries.
 - Read-only disk analysis plus confirmed cleanup of allowlisted data.
 - Clone, rename, erase, delete, and Finder shortcuts.
 
@@ -115,7 +115,7 @@ simslim on <udid> --keep com.apple.apsd
 
 ## How it works
 
-`simslim on` writes persistent `launchctl disable` entries for the chosen daemons into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only daemons that are safe to disable (the handful that wedge a simulator when turned off are left alone).
+`simslim on` writes persistent `launchctl disable` entries for the chosen daemons into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only daemons that are safe to disable. Core workflow services such as `sharingd`, plus the handful that wedge a simulator when turned off, are left running.
 
 This is per-simulator state, not a global setting. The daemon disables live in that one simulator's launchd database. `simslim clone` preserves them, but `erase`, `delete` and recreate, or "Erase All Content and Settings" reset the simulator to stock, so you'll need to run `simslim on` again and its memory will climb back to stock until you do. A simulator created from a new or updated runtime also starts stock. Run `simslim list` to see which simulators are currently slim.
 
@@ -128,7 +128,7 @@ Turning services off is fine for most development, UI automation, and CI, but so
 - Universal links need `swcd` (`web`).
 - The Contacts, Photos, and Calendar pickers can act up without their categories.
 
-`simslim profiles` lists every category, so you can keep the ones your work depends on with `--except`.
+`simslim profiles` lists every category, so you can keep a category with `--except` or individual daemons with `--keep`.
 
 ## Why
 

--- a/docs/category-memory.md
+++ b/docs/category-memory.md
@@ -30,10 +30,17 @@ category run's median minus that baseline, rounded to a useful GUI value.
 | Photos & Media Analysis | 57.9 MiB | 60 MB |
 | News, Weather, Maps & Games | 88.1 MiB | 90 MB |
 | Messaging & FaceTime | 60.2 MiB | 60 MB |
-| Sharing & Device Connectivity | 83.6 MiB | 85 MB |
+| Sharing & Device Connectivity | 64.4 MiB | 65 MB |
 | Ads, Diagnostics & Telemetry | 106.0 MiB | 105 MB |
 | Other Background Services | 194.0 MiB | 195 MB |
 
 These deltas are not additive. Services share caches and dependencies, and
 their footprint changes with simulator runtime, boot age, installed apps, and
 active workload.
+
+The connectivity category was remeasured after `sharingd` became always-on to
+preserve system share sheets. Three alternating clean-boot pairs compared the
+remaining 11 daemons after the same 20-second settle. Their median deltas were
+64.4, 46.4, and 73.4 MiB; the median pair gives the 65 MB GUI estimate. Seven of
+those daemons stayed resident at idle and directly totaled about 76.2 MiB. The
+whole-simulator delta is used above for consistency with the other categories.

--- a/gui/AppModel.swift
+++ b/gui/AppModel.swift
@@ -16,6 +16,7 @@ final class AppModel: ObservableObject {
   @Published private(set) var lastUpdated: Date?
   @Published var selectedUDIDs: Set<String> = []
   @Published var keptCategoryIDs: Set<String> = []
+  @Published var keptServiceLabels: Set<String> = []
   @Published var selectedDiskCleanupCategoryIDs: Set<String> = []
   @Published var preserveBootState = true
   @Published var presentedError: PresentedError?
@@ -46,9 +47,10 @@ final class AppModel: ObservableObject {
   }
 
   var disabledDaemonCount: Int {
-    categories
-      .filter { !keptCategoryIDs.contains($0.id) }
-      .reduce(0) { $0 + $1.labels.count }
+    categories.reduce(0) { count, category in
+      guard !categoryIsKept(category) else { return count }
+      return count + category.labels.filter { !keptServiceLabels.contains($0) }.count
+    }
   }
 
   var bootedCount: Int { devices.filter(\.isBooted).count }
@@ -136,8 +138,12 @@ final class AppModel: ObservableObject {
   }
 
   func slimState(for device: SimulatorDevice) -> ServiceSlimState {
-    let disabled = device.managedDisabled ?? lastKnownDisabled[device.udid]
-    guard let disabled else { return .unknown }
+    let cachedOrLiveDisabled = device.managedDisabled ?? lastKnownDisabled[device.udid]
+    guard let cachedOrLiveDisabled else { return .unknown }
+    // Profile updates can remove a daemon from the slimmable set. Clamp an
+    // older shutdown-state cache to the current total until the device boots
+    // and supplies a fresh live count.
+    let disabled = min(max(cachedOrLiveDisabled, 0), device.managedTotal)
     switch disabled {
     case 0:
       return .stock
@@ -178,13 +184,43 @@ final class AppModel: ObservableObject {
   func setCategory(_ category: SlimCategory, keptEnabled: Bool) {
     if keptEnabled {
       keptCategoryIDs.insert(category.id)
+      keptServiceLabels.subtract(category.labels)
     } else {
       keptCategoryIDs.remove(category.id)
+      keptServiceLabels.subtract(category.labels)
     }
+  }
+
+  func categoryIsKept(_ category: SlimCategory) -> Bool {
+    keptCategoryIDs.contains(category.id)
+      || category.labels.allSatisfy { keptServiceLabels.contains($0) }
+  }
+
+  func serviceIsKept(_ label: String, in category: SlimCategory) -> Bool {
+    categoryIsKept(category) || keptServiceLabels.contains(label)
+  }
+
+  func setService(_ label: String, in category: SlimCategory, keptEnabled: Bool) {
+    guard category.labels.contains(label) else { return }
+
+    if keptEnabled {
+      keptServiceLabels.insert(label)
+      if category.labels.allSatisfy({ keptServiceLabels.contains($0) }) {
+        keptCategoryIDs.insert(category.id)
+        keptServiceLabels.subtract(category.labels)
+      }
+      return
+    }
+
+    if keptCategoryIDs.remove(category.id) != nil {
+      keptServiceLabels.formUnion(category.labels)
+    }
+    keptServiceLabels.remove(label)
   }
 
   func resetProfile() {
     keptCategoryIDs.removeAll()
+    keptServiceLabels.removeAll()
   }
 
   func setDiskCleanupCategory(_ category: DiskCleanupCategory, selected: Bool) {
@@ -554,6 +590,7 @@ final class AppModel: ObservableObject {
       let output = try await backend.slim(
         udid: device.udid,
         exceptCategories: keptCategoryIDs,
+        keepLabels: keptServiceLabels,
         preserveBootState: preserveBootState
       )
       setCachedDisabled(disabledDaemonCount, for: device.udid)

--- a/gui/Backend.swift
+++ b/gui/Backend.swift
@@ -79,12 +79,18 @@ struct SimSlimBackend {
     return try await decode(SimulatorDiskCleanupResult.self, arguments: arguments)
   }
 
-  func slim(udid: String, exceptCategories: Set<String>, preserveBootState: Bool) async throws
-    -> String
-  {
+  func slim(
+    udid: String,
+    exceptCategories: Set<String>,
+    keepLabels: Set<String>,
+    preserveBootState: Bool
+  ) async throws -> String {
     var arguments = ["on"]
     if !exceptCategories.isEmpty {
       arguments.append(contentsOf: ["--except", exceptCategories.sorted().joined(separator: ",")])
+    }
+    if !keepLabels.isEmpty {
+      arguments.append(contentsOf: ["--keep", keepLabels.sorted().joined(separator: ",")])
     }
     if preserveBootState {
       arguments.append("--preserve-boot-state")

--- a/gui/ContentView.swift
+++ b/gui/ContentView.swift
@@ -462,6 +462,7 @@ private struct MetricPill: View {
 private struct ProfileSidebar: View {
   @EnvironmentObject private var model: AppModel
   @Binding var mode: SlimmingMode
+  @State private var serviceSearchText = ""
 
   var body: some View {
     VStack(spacing: 0) {
@@ -517,6 +518,26 @@ private struct ProfileSidebar: View {
     }
   }
 
+  private var filteredMemoryCategories: [SlimCategory] {
+    let query = serviceSearchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !query.isEmpty else { return sortedMemoryCategories }
+    return sortedMemoryCategories.filter { category in
+      category.name.localizedCaseInsensitiveContains(query)
+        || category.description.localizedCaseInsensitiveContains(query)
+        || category.downside.localizedCaseInsensitiveContains(query)
+        || category.labels.contains {
+          $0.localizedCaseInsensitiveContains(query)
+        }
+        || category.labels.contains {
+          category.serviceDescription(for: $0).localizedCaseInsensitiveContains(query)
+        }
+        || category.alwaysEnabledServices.contains {
+          $0.label.localizedCaseInsensitiveContains(query)
+            || $0.reason.localizedCaseInsensitiveContains(query)
+        }
+    }
+  }
+
   private var sortedDiskCategories: [DiskCleanupCategory] {
     model.diskCleanupCategories.filter(\.canClean).sorted {
       let left = model.diskCleanupBytes(for: $0.id) ?? 0
@@ -541,7 +562,8 @@ private struct ProfileSidebar: View {
           Button("Full Slim") { model.resetProfile() }
             .buttonStyle(.plain)
             .foregroundStyle(.tint)
-            .disabled(model.keptCategoryIDs.isEmpty || model.isBusy)
+            .disabled(
+              (model.keptCategoryIDs.isEmpty && model.keptServiceLabels.isEmpty) || model.isBusy)
         }
         Text(
           "Sorted by estimated idle memory use. Enable categories your tests need; estimates vary and are not additive."
@@ -551,9 +573,23 @@ private struct ProfileSidebar: View {
         .fixedSize(horizontal: false, vertical: true)
       }
 
+      SidebarServiceSearch(text: $serviceSearchText)
+
       VStack(alignment: .leading, spacing: 8) {
-        ForEach(sortedMemoryCategories) { category in
-          CategoryToggle(category: category)
+        ForEach(filteredMemoryCategories) { category in
+          CategoryToggle(
+            category: category,
+            serviceQuery: serviceSearchText
+          )
+        }
+
+        if !serviceSearchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+          && filteredMemoryCategories.isEmpty
+        {
+          Text("No services match \u{201c}\(serviceSearchText)\u{201d}")
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, minHeight: 72)
         }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
@@ -572,7 +608,7 @@ private struct ProfileSidebar: View {
         Label("\(model.disabledDaemonCount) services will be disabled", systemImage: "circle")
           .font(.subheadline.weight(.semibold))
           .foregroundStyle(.green)
-        Text("Deadlock-prone daemons are excluded by the CLI and never touched.")
+        Text("Core workflow and deadlock-prone daemons are never disabled.")
           .font(.caption)
           .foregroundStyle(.secondary)
       }
@@ -662,6 +698,39 @@ private struct ProfileSidebar: View {
         LegendItem(icon: "circle", label: "Slim")
       }
       .foregroundStyle(.secondary)
+    }
+  }
+}
+
+private struct SidebarServiceSearch: View {
+  @Binding var text: String
+
+  var body: some View {
+    HStack(spacing: 7) {
+      Image(systemName: "magnifyingglass")
+        .foregroundStyle(.secondary)
+
+      TextField("Find a service", text: $text)
+        .textFieldStyle(.plain)
+        .accessibilityLabel("Find a service")
+
+      if !text.isEmpty {
+        Button {
+          text = ""
+        } label: {
+          Image(systemName: "xmark.circle.fill")
+            .foregroundStyle(.secondary)
+        }
+        .buttonStyle(.plain)
+        .help("Clear service search")
+      }
+    }
+    .padding(.horizontal, 9)
+    .frame(height: 29)
+    .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 7))
+    .overlay {
+      RoundedRectangle(cornerRadius: 7)
+        .stroke(Color(nsColor: .separatorColor).opacity(0.7), lineWidth: 0.5)
     }
   }
 }
@@ -786,53 +855,202 @@ private struct LegendItem: View {
 private struct CategoryToggle: View {
   @EnvironmentObject private var model: AppModel
   let category: SlimCategory
+  let serviceQuery: String
+  @State private var isExpanded = false
 
   private var isKeptEnabled: Binding<Bool> {
     Binding(
-      get: { model.keptCategoryIDs.contains(category.id) },
+      get: { model.categoryIsKept(category) },
       set: { model.setCategory(category, keptEnabled: $0) }
     )
   }
 
+  private var showsServices: Bool {
+    isExpanded || !normalizedQuery.isEmpty
+  }
+
+  private var serviceCount: Int {
+    category.labels.count + category.alwaysEnabledServices.count
+  }
+
+  private var normalizedQuery: String {
+    serviceQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var categoryMetadataMatchesQuery: Bool {
+    guard !normalizedQuery.isEmpty else { return false }
+    return category.name.localizedCaseInsensitiveContains(normalizedQuery)
+      || category.description.localizedCaseInsensitiveContains(normalizedQuery)
+      || category.downside.localizedCaseInsensitiveContains(normalizedQuery)
+  }
+
+  private var visibleLabels: [String] {
+    guard !normalizedQuery.isEmpty, !categoryMetadataMatchesQuery else { return category.labels }
+    return category.labels.filter {
+      $0.localizedCaseInsensitiveContains(normalizedQuery)
+        || category.serviceDescription(for: $0).localizedCaseInsensitiveContains(normalizedQuery)
+    }
+  }
+
+  private var visibleAlwaysEnabledServices: [AlwaysEnabledService] {
+    guard !normalizedQuery.isEmpty, !categoryMetadataMatchesQuery else {
+      return category.alwaysEnabledServices
+    }
+    return category.alwaysEnabledServices.filter {
+      $0.label.localizedCaseInsensitiveContains(normalizedQuery)
+        || $0.reason.localizedCaseInsensitiveContains(normalizedQuery)
+    }
+  }
+
   var body: some View {
-    HStack(alignment: .top, spacing: 12) {
-      VStack(alignment: .leading, spacing: 6) {
-        HStack(spacing: 6) {
-          Text(category.name)
-            .font(.subheadline.weight(.medium))
-            .fixedSize(horizontal: false, vertical: true)
-          Text("\(category.labels.count)")
-            .font(.caption2.monospacedDigit())
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 1)
-            .background(.quaternary, in: Capsule())
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(alignment: .top, spacing: 10) {
+        Button {
+          withAnimation(.easeInOut(duration: 0.16)) {
+            isExpanded.toggle()
+          }
+        } label: {
+          HStack(alignment: .firstTextBaseline, spacing: 7) {
+            Image(systemName: showsServices ? "chevron.down" : "chevron.right")
+              .font(.caption2.weight(.bold))
+              .foregroundStyle(.secondary)
+              .frame(width: 9)
+
+            Text(category.name)
+              .font(.subheadline.weight(.medium))
+              .fixedSize(horizontal: false, vertical: true)
+
+            Text("\(serviceCount)")
+              .font(.caption2.monospacedDigit())
+              .foregroundStyle(.secondary)
+              .padding(.horizontal, 5)
+              .padding(.vertical, 1)
+              .background(.quaternary, in: Capsule())
+          }
         }
+        .buttonStyle(.plain)
+        .help(showsServices ? "Hide individual services" : "Show individual services")
 
-        Label(category.approximateMemoryText, systemImage: "memorychip")
-          .font(.caption.weight(.semibold))
-          .foregroundStyle(.blue)
-          .padding(.horizontal, 7)
-          .padding(.vertical, 3)
-          .background(Color.blue.opacity(0.1), in: Capsule())
+        Spacer(minLength: 4)
 
-        (Text("When disabled: ").fontWeight(.semibold) + Text(category.downside))
-          .font(.caption)
-          .foregroundStyle(.secondary)
-          .fixedSize(horizontal: false, vertical: true)
+        Toggle("Keep \(category.name) enabled", isOn: isKeptEnabled)
+          .labelsHidden()
+          .toggleStyle(.switch)
+          .disabled(model.isBusy)
+          .padding(.top, 1)
+          .help("Keep all controllable services in \(category.name) enabled")
       }
-      .frame(maxWidth: .infinity, alignment: .leading)
 
-      Toggle("Keep \(category.name) enabled", isOn: isKeptEnabled)
-        .labelsHidden()
-        .toggleStyle(.switch)
-        .disabled(model.isBusy)
-        .padding(.top, 1)
+      Label(category.approximateMemoryText, systemImage: "memorychip")
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.blue)
+        .padding(.horizontal, 7)
+        .padding(.vertical, 3)
+        .background(Color.blue.opacity(0.1), in: Capsule())
+        .help(category.approximateMemoryText)
+
+      (Text("When disabled: ").fontWeight(.semibold) + Text(category.downside))
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      if showsServices {
+        Divider()
+
+        VStack(alignment: .leading, spacing: 6) {
+          ForEach(visibleLabels, id: \.self) { label in
+            ServiceToggle(label: label, category: category)
+          }
+
+          ForEach(visibleAlwaysEnabledServices) { service in
+            AlwaysEnabledServiceRow(service: service)
+          }
+        }
+        .transition(.opacity.combined(with: .move(edge: .top)))
+      }
     }
     .padding(10)
     .frame(maxWidth: .infinity, alignment: .leading)
     .background(Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 9))
-    .help("Keep \(category.name) enabled (approximately \(category.approxMemoryMB) MB at idle)")
+  }
+}
+
+private struct ServiceToggle: View {
+  @EnvironmentObject private var model: AppModel
+  let label: String
+  let category: SlimCategory
+
+  private var isKeptEnabled: Binding<Bool> {
+    Binding(
+      get: { model.serviceIsKept(label, in: category) },
+      set: { model.setService(label, in: category, keptEnabled: $0) }
+    )
+  }
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "gearshape.2")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .frame(width: 15)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(label)
+          .font(.caption.monospaced())
+          .lineLimit(2)
+          .textSelection(.enabled)
+        Text(category.serviceDescription(for: label))
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .lineLimit(2)
+      }
+
+      Spacer(minLength: 4)
+
+      Toggle("Keep \(label) enabled", isOn: isKeptEnabled)
+        .labelsHidden()
+        .toggleStyle(.switch)
+        .controlSize(.mini)
+        .disabled(model.isBusy)
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 6)
+    .background(.quaternary.opacity(0.45), in: RoundedRectangle(cornerRadius: 7))
+  }
+}
+
+private struct AlwaysEnabledServiceRow: View {
+  let service: AlwaysEnabledService
+
+  var body: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "lock.fill")
+        .font(.caption)
+        .foregroundStyle(.blue)
+        .frame(width: 15)
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(service.label)
+          .font(.caption.monospaced())
+          .lineLimit(2)
+          .textSelection(.enabled)
+        Text(service.reason)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+
+      Spacer(minLength: 4)
+
+      Text("Always on")
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(.blue)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(Color.blue.opacity(0.1), in: Capsule())
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 6)
+    .background(Color.blue.opacity(0.05), in: RoundedRectangle(cornerRadius: 7))
   }
 }
 

--- a/gui/Models.swift
+++ b/gui/Models.swift
@@ -29,10 +29,27 @@ struct SlimCategory: Decodable, Identifiable, Equatable {
   let downside: String
   let approxMemoryMB: Int
   let labels: [String]
+  let serviceDescriptions: [String: String]?
+  let alwaysEnabled: [AlwaysEnabledService]?
+
+  var alwaysEnabledServices: [AlwaysEnabledService] {
+    alwaysEnabled ?? []
+  }
 
   var approximateMemoryText: String {
     "Uses ~\(approxMemoryMB) MB RAM"
   }
+
+  func serviceDescription(for label: String) -> String {
+    serviceDescriptions?[label] ?? "Apple background service."
+  }
+}
+
+struct AlwaysEnabledService: Decodable, Identifiable, Equatable {
+  let label: String
+  let reason: String
+
+  var id: String { label }
 }
 
 struct SimulatorMeasurement: Decodable, Equatable {

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func cmdList(ctx context.Context, args []string) error {
 		}
 		return devices[i].Name < devices[j].Name
 	})
-	managed := len(managedSet())
+	managed := len(slimmableSet())
 	memoryByUDID := map[string]Measurement{}
 	memoryErrors := map[string]string{}
 	if jsonOutput {
@@ -161,9 +161,12 @@ func cmdProfiles(args []string) error {
 		fmt.Printf("%-14s %s\n", c.ID, c.Name)
 		fmt.Printf("               %d daemons · ~%d MB idle footprint when enabled\n", len(c.Labels), c.ApproxMemoryMB)
 		fmt.Printf("               When disabled: %s\n", c.Downside)
+		for _, service := range c.AlwaysEnabled {
+			fmt.Printf("               Always on: %s — %s\n", service.Label, service.Reason)
+		}
 	}
-	fmt.Printf("\n%d daemons across %d categories. Deadlock-prone daemons are excluded and never touched.\n",
-		len(managedSet()), len(Categories))
+	fmt.Printf("\n%d daemons across %d categories. Core workflow and deadlock-prone daemons are never disabled.\n",
+		len(slimmableSet()), len(Categories))
 	fmt.Println("Memory estimates are iOS 26.5 clean-boot measurements; they vary by runtime and workload and are not additive.")
 	return nil
 }

--- a/profiles.go
+++ b/profiles.go
@@ -4,21 +4,28 @@ import "sort"
 
 // Category groups launchd daemon labels that a slim boot disables together.
 type Category struct {
-	ID             string   `json:"id"`
-	Name           string   `json:"name"`
-	Description    string   `json:"description"`
-	Downside       string   `json:"downside"`
-	ApproxMemoryMB int      `json:"approxMemoryMB"`
-	Labels         []string `json:"labels"`
+	ID                  string                 `json:"id"`
+	Name                string                 `json:"name"`
+	Description         string                 `json:"description"`
+	Downside            string                 `json:"downside"`
+	ApproxMemoryMB      int                    `json:"approxMemoryMB"`
+	Labels              []string               `json:"labels"`
+	ServiceDescriptions map[string]string      `json:"serviceDescriptions"`
+	AlwaysEnabled       []AlwaysEnabledService `json:"alwaysEnabled,omitempty"`
 }
 
-// Categories is the complete allowlist of disable-safe daemons. A label that
-// is not in some category here is never disabled or re-enabled, which is what
-// keeps deadlock-inducing daemons (see forbiddenLabels in profiles_test.go)
-// permanently out of reach. ApproxMemoryMB is the rounded median increase in
-// phys_footprint when only that category is kept on versus a fully slim iOS
-// 26.5 clean boot. The estimates vary by runtime and workload and are not
-// additive.
+// AlwaysEnabledService is shown alongside a category for transparency but is
+// never included in a slim profile. Earlier versions may have disabled it, so
+// it remains in the mutation allowlist solely to repair that legacy state.
+type AlwaysEnabledService struct {
+	Label  string `json:"label"`
+	Reason string `json:"reason"`
+}
+
+// Categories is the complete allowlist of daemons a profile may disable.
+// ApproxMemoryMB values are rounded median increases in phys_footprint when
+// only that category is kept on versus a fully slim iOS 26.5 clean boot. The
+// estimates vary by runtime and workload and are not additive.
 var Categories = []Category{
 	{
 		ID:             "widgets",
@@ -267,9 +274,8 @@ var Categories = []Category{
 		Name:           "Sharing & Device Connectivity",
 		Description:    "AirDrop, Continuity, CarPlay, Watch, and Find My services.",
 		Downside:       "AirDrop, Continuity, CarPlay, Watch, and Find My connectivity will not work.",
-		ApproxMemoryMB: 85,
+		ApproxMemoryMB: 65,
 		Labels: []string{
-			"com.apple.sharingd",
 			"com.apple.rapportd",
 			"com.apple.companiond",
 			"com.apple.carkitd",
@@ -281,6 +287,12 @@ var Categories = []Category{
 			"com.apple.announced",
 			"com.apple.navd",
 			"com.apple.findmy.findmylocated",
+		},
+		AlwaysEnabled: []AlwaysEnabledService{
+			{
+				Label:  "com.apple.sharingd",
+				Reason: "Required for system share sheets.",
+			},
 		},
 	},
 	{
@@ -337,13 +349,24 @@ func categoryByID(id string) (Category, bool) {
 	return Category{}, false
 }
 
-// managedSet is every label under management: the only labels that may ever be
-// disabled or re-enabled. Everything else on the device is left untouched.
-func managedSet() map[string]bool {
+// slimmableSet is every label a service profile may disable.
+func slimmableSet() map[string]bool {
 	set := make(map[string]bool)
 	for _, c := range Categories {
 		for _, l := range c.Labels {
 			set[l] = true
+		}
+	}
+	return set
+}
+
+// managedSet is the complete mutation allowlist. Most labels are slimmable;
+// required labels may only transition back to enabled for compatibility.
+func managedSet() map[string]bool {
+	set := slimmableSet()
+	for _, category := range Categories {
+		for _, service := range category.AlwaysEnabled {
+			set[service.Label] = true
 		}
 	}
 	return set

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,65 @@ func TestNoDuplicateLabels(t *testing.T) {
 			}
 			seen[l] = c.ID
 		}
+	}
+}
+
+func TestEveryServiceHasShortDescription(t *testing.T) {
+	known := map[string]bool{}
+	for _, category := range Categories {
+		if len(category.ServiceDescriptions) != len(category.Labels) {
+			t.Errorf("category %q has %d labels but %d service descriptions", category.ID, len(category.Labels), len(category.ServiceDescriptions))
+		}
+		for _, label := range category.Labels {
+			known[label] = true
+			description, ok := category.ServiceDescriptions[label]
+			if !ok || strings.TrimSpace(description) == "" {
+				t.Errorf("service %q has no user-facing description", label)
+			}
+			if strings.ContainsAny(description, "\r\n") {
+				t.Errorf("service %q description must stay on one logical line", label)
+			}
+			if len(description) > 90 {
+				t.Errorf("service %q description is too long (%d characters)", label, len(description))
+			}
+		}
+	}
+	for label := range serviceDescriptionByLabel {
+		if !known[label] {
+			t.Errorf("description exists for unmanaged service %q", label)
+		}
+	}
+}
+
+func TestRequiredEnabledLabelsAreNeverSlimmed(t *testing.T) {
+	slimmable := slimmableSet()
+	managed := managedSet()
+	profile := Profile{ExceptCategories: map[string]bool{}, Keep: map[string]bool{}}
+	desired := profile.desired()
+	for _, category := range Categories {
+		for _, service := range category.AlwaysEnabled {
+			if slimmable[service.Label] || desired[service.Label] {
+				t.Errorf("required daemon %q is included in a slim profile", service.Label)
+			}
+			if !managed[service.Label] {
+				t.Errorf("required daemon %q is missing from the repair allowlist", service.Label)
+			}
+			if service.Reason == "" {
+				t.Errorf("required daemon %q has no user-facing reason", service.Label)
+			}
+		}
+	}
+}
+
+func TestDeltaRepairsRequiredEnabledLabels(t *testing.T) {
+	current := map[string]bool{"com.apple.sharingd": true}
+	desired := Profile{ExceptCategories: map[string]bool{}, Keep: map[string]bool{}}.desired()
+	toDisable, toEnable := delta(current, desired, managedSet())
+	if len(toDisable) == 0 {
+		t.Fatal("full profile should still disable slimmable labels")
+	}
+	if !reflect.DeepEqual(toEnable, []string{"com.apple.sharingd"}) {
+		t.Errorf("toEnable = %v, want [com.apple.sharingd]", toEnable)
 	}
 }
 

--- a/service_descriptions.go
+++ b/service_descriptions.go
@@ -1,0 +1,216 @@
+package main
+
+// serviceDescriptionByLabel gives the GUI a short, user-facing explanation for
+// every daemon that can be controlled individually. These descriptions explain
+// the service's primary role without implying that private Apple daemons have a
+// stable public API or an isolated memory cost.
+var serviceDescriptionByLabel = map[string]string{
+	// Widgets & Wallpaper
+	"com.apple.PosterBoard":     "Renders Home and Lock Screen wallpaper scenes.",
+	"com.apple.chronod":         "Refreshes widgets and complications on schedule.",
+	"com.apple.liveactivitiesd": "Updates Live Activities and Dynamic Island content.",
+
+	// Siri & Intelligence
+	"com.apple.assistantd":             "Coordinates Siri requests and assistant state.",
+	"com.apple.assistant_cdmd":         "Routes commands and intents submitted to Siri.",
+	"com.apple.assistant_service":      "Provides supporting services for Siri requests.",
+	"com.apple.siriactionsd":           "Executes Siri actions and App Intents.",
+	"com.apple.siriinferenced":         "Runs Siri inference and intent predictions.",
+	"com.apple.siriknowledged":         "Maintains knowledge and context used by Siri.",
+	"com.apple.sirittsd":               "Generates Siri's spoken responses.",
+	"com.apple.siri.context.service":   "Builds device context for Siri requests.",
+	"com.apple.siri.acousticsignature": "Processes acoustic signatures for voice features.",
+	"com.apple.corespeechd":            "Provides speech recognition and voice-trigger services.",
+	"com.apple.voiced":                 "Manages system voices and speech assets.",
+	"com.apple.voicebankingd":          "Supports Personal Voice and voice banking.",
+	"com.apple.speechmodeltrainingd":   "Adapts on-device speech recognition models.",
+	"com.apple.intelligenceplatformd":  "Coordinates Apple Intelligence services.",
+	"com.apple.intelligencecontextd":   "Collects local context for intelligence features.",
+	"com.apple.intelligenceflowd":      "Orchestrates Apple Intelligence workflows.",
+	"com.apple.intelligencetasksd":     "Runs background Apple Intelligence tasks.",
+	"com.apple.generativeexperiencesd": "Supports generative intelligence experiences.",
+	"com.apple.knowledgeconstructiond": "Builds on-device knowledge used by suggestions.",
+	"com.apple.naturallanguaged":       "Performs natural-language analysis.",
+	"com.apple.textunderstandingd":     "Extracts meaning and entities from text.",
+	"com.apple.modelcatalogd":          "Tracks machine-learning models available to the system.",
+	"com.apple.modelmanagerd":          "Downloads and manages on-device models.",
+	"com.apple.mlhostd":                "Hosts system machine-learning services.",
+	"com.apple.mlruntimed":             "Executes on-device machine-learning models.",
+	"com.apple.suggestd":               "Generates system suggestions and predictions.",
+	"com.apple.parsecd":                "Provides network-backed Siri and Spotlight suggestions.",
+	"com.apple.parsec-fbf":             "Collects feedback for Siri and Spotlight suggestions.",
+	"com.apple.proactiveeventtrackerd": "Tracks events used by proactive suggestions.",
+
+	// Spotlight & Search
+	"com.apple.searchd":                     "Coordinates system search queries.",
+	"com.apple.searchtoold":                 "Runs helper tasks for system search.",
+	"com.apple.spotlightknowledged":         "Builds knowledge used by Spotlight results.",
+	"com.apple.spotlightknowledged.updater": "Refreshes Spotlight's knowledge data.",
+	"com.apple.corespotlightservice":        "Indexes and searches app-provided content.",
+
+	// iCloud & Apple Account
+	"com.apple.appleaccountd":                                  "Maintains Apple Account state on the device.",
+	"com.apple.appleaccounttransparencyd":                      "Checks Apple Account security records.",
+	"com.apple.appleidsetupd":                                  "Handles Apple Account setup workflows.",
+	"com.apple.akd":                                            "Provides Apple Account authentication tokens.",
+	"com.apple.amsaccountsd":                                   "Manages App Store and media account state.",
+	"com.apple.amsengagementd":                                 "Handles App Store and media engagement messages.",
+	"com.apple.amsondevicestoraged":                            "Stores Apple media-service data on the device.",
+	"com.apple.cloudd":                                         "Synchronizes CloudKit databases and records.",
+	"com.apple.cloudphotod":                                    "Synchronizes the iCloud Photos library.",
+	"com.apple.ckdiscretionaryd":                               "Schedules non-urgent CloudKit transfers.",
+	"com.apple.cloudsettingssyncagent":                         "Synchronizes supported system settings through iCloud.",
+	"com.apple.bird":                                           "Synchronizes iCloud Drive files.",
+	"com.apple.syncdefaultsd":                                  "Synchronizes supported preferences between devices.",
+	"com.apple.cdpd":                                           "Handles iCloud data-protection setup and recovery.",
+	"com.apple.sosd":                                           "Synchronizes iCloud Keychain secure items.",
+	"com.apple.SecureBackupDaemon":                             "Handles secure backup and account recovery data.",
+	"com.apple.TrustedPeersHelper":                             "Maintains trusted peers for iCloud Keychain.",
+	"com.apple.protectedcloudstorage.protectedcloudkeysyncing": "Synchronizes protected cloud encryption keys.",
+	"com.apple.icloudmailagent":                                "Runs background services for iCloud Mail.",
+	"com.apple.icloudsubscriptionoptimizerd":                   "Evaluates iCloud storage subscription recommendations.",
+	"com.apple.communicationtrustd":                            "Maintains communication trust and safety state.",
+
+	// App Store, Push & Media
+	"com.apple.appstored":           "Installs and updates apps from the App Store.",
+	"com.apple.appstorecomponentsd": "Provides background components used by the App Store.",
+	"com.apple.apsd":                "Receives Apple Push Notification service messages.",
+	"com.apple.itunescloudd":        "Synchronizes purchased and cloud media libraries.",
+	"com.apple.itunesstored":        "Handles media-store accounts and purchases.",
+	"com.apple.storekitd":           "Processes StoreKit products and transactions.",
+	"com.apple.videosubscriptionsd": "Manages video subscriptions and TV providers.",
+	"com.apple.assetsubscriptiond":  "Manages subscribed media assets and downloads.",
+	"com.apple.musicd":              "Runs background Music library and playback services.",
+
+	// Mail, Calendar & Contacts
+	"com.apple.email.maild":            "Fetches, indexes, and sends Mail account data.",
+	"com.apple.exchangesyncd":          "Synchronizes Microsoft Exchange account data.",
+	"com.apple.dataaccess.dataaccessd": "Synchronizes CalDAV, CardDAV, and related accounts.",
+	"com.apple.calaccessd":             "Provides access to Calendar event data.",
+	"com.apple.remindd":                "Stores and synchronizes reminders.",
+	"com.apple.contactsd":              "Provides access to the Contacts database.",
+	"com.apple.contacts.postersyncd":   "Synchronizes Contact Posters.",
+	"com.apple.peopled":                "Builds people and relationship suggestions.",
+
+	// Safari Sync & Web Services
+	"com.apple.SafariBookmarksSyncAgent":    "Synchronizes Safari bookmarks through iCloud.",
+	"com.apple.Safari.History":              "Maintains and synchronizes Safari history.",
+	"com.apple.Safari.passwordbreachd":      "Checks saved passwords for known data leaks.",
+	"com.apple.Safari.SafeBrowsing.Service": "Checks sites against unsafe browsing data.",
+	"com.apple.safarifetcherd":              "Fetches Safari content in the background.",
+	"com.apple.WebBookmarks.webbookmarksd":  "Maintains web bookmarks, clips, and Reading List data.",
+	"com.apple.webkit.adattributiond":       "Processes privacy-preserving web ad attribution.",
+	"com.apple.webkit.webpushd":             "Receives push notifications for websites.",
+	"com.apple.webprivacyd":                 "Maintains Safari privacy-protection data.",
+	"com.apple.swcd":                        "Matches universal links with installed apps.",
+
+	// Family & Screen Time
+	"com.apple.familycircled":           "Maintains Family Sharing membership and state.",
+	"com.apple.FamilyControlsAgent":     "Applies parental and Family Controls restrictions.",
+	"com.apple.familynotification":      "Delivers Family Sharing invitations and notices.",
+	"com.apple.askpermissiond":          "Handles Ask to Buy permission requests.",
+	"com.apple.asktod":                  "Routes family approval prompts and responses.",
+	"com.apple.ScreenTimeAgent":         "Enforces Screen Time limits and reports usage.",
+	"com.apple.ScreenTimeSettingsAgent": "Connects Screen Time data to Settings.",
+	"com.apple.UsageTrackingAgent":      "Tracks app and website usage duration.",
+
+	// Health, Home & Fitness
+	"com.apple.healthd":              "Stores and serves HealthKit data.",
+	"com.apple.healthappd":           "Runs background tasks for the Health app.",
+	"com.apple.healthcontentd":       "Provides educational and recommended health content.",
+	"com.apple.healtheventsd":        "Processes health events and related notifications.",
+	"com.apple.healthrecordsd":       "Synchronizes clinical health records.",
+	"com.apple.finhealthd":           "Analyzes Wallet transactions and financial-health data.",
+	"com.apple.homed":                "Manages HomeKit accessories, rooms, and automations.",
+	"com.apple.homeeventsd":          "Processes HomeKit events and automation triggers.",
+	"com.apple.fitcore":              "Runs Apple Fitness content and background services.",
+	"com.apple.fitcore.session":      "Manages active Apple Fitness sessions.",
+	"com.apple.fitnesscoachingd":     "Provides Fitness coaching recommendations.",
+	"com.apple.fitnessintelligenced": "Generates personalized Fitness insights.",
+	"com.apple.activityawardsd":      "Tracks Activity awards and achievements.",
+	"com.apple.activitysharingd":     "Synchronizes shared Activity and Fitness data.",
+
+	// Photos & Media Analysis
+	"com.apple.photoanalysisd":         "Analyzes photos for scenes, people, and search.",
+	"com.apple.photosface":             "Performs face detection for the Photos library.",
+	"com.apple.mediaanalysisd":         "Analyzes image, video, and audio content.",
+	"com.apple.mediaanalysisd.service": "Runs isolated media-analysis work.",
+	"com.apple.mediastream.mstreamd":   "Synchronizes shared and streamed photo content.",
+	"com.apple.medialibraryd":          "Maintains the system media library database.",
+	"com.apple.assetsd":                "Provides access to Photos library assets.",
+	"com.apple.assetsd.nebulad":        "Handles cloud-backed Photos asset transfers.",
+
+	// News, Weather, Maps & Games
+	"com.apple.newsd":                          "Downloads and refreshes Apple News content.",
+	"com.apple.weatherd":                       "Fetches forecasts and weather data.",
+	"com.apple.Maps.mapssyncd":                 "Synchronizes Maps favorites, guides, and history.",
+	"com.apple.Maps.mapspushd":                 "Receives background updates for Maps.",
+	"com.apple.Maps.geocorrectiond":            "Improves and corrects map location data.",
+	"com.apple.maps.destinationd":              "Predicts and maintains suggested destinations.",
+	"com.apple.MapKit.SnapshotService":         "Renders static map snapshots for apps.",
+	"com.apple.jetpackassetd":                  "Downloads assets used by Apple content apps.",
+	"com.apple.tipsd":                          "Selects and refreshes content for the Tips app.",
+	"com.apple.gamed":                          "Provides Game Center accounts and multiplayer state.",
+	"com.apple.gamesaved":                      "Synchronizes supported game save data.",
+	"com.apple.GameController.gamecontrollerd": "Discovers controllers and routes their input.",
+
+	// Messaging & FaceTime
+	"com.apple.identityservicesd":                  "Maintains identities used by iMessage and FaceTime.",
+	"com.apple.ids_simd":                           "Provides simulator support for Apple identity services.",
+	"com.apple.imautomatichistorydeletionagent":    "Removes Messages history according to retention settings.",
+	"com.apple.imcore.imtransferagent":             "Transfers Messages attachments and media.",
+	"com.apple.imdpersistence.IMDPersistenceAgent": "Stores Messages conversations and metadata.",
+	"com.apple.facetimemessagestored":              "Stores FaceTime messages and related data.",
+	"com.apple.telephonyutilities.callservicesd":   "Coordinates FaceTime and system call state.",
+
+	// Sharing & Device Connectivity
+	"com.apple.rapportd":             "Discovers nearby devices for Continuity features.",
+	"com.apple.companiond":           "Coordinates communication with paired companion devices.",
+	"com.apple.carkitd":              "Provides CarPlay connection and vehicle services.",
+	"com.apple.wcd":                  "Handles connectivity with a paired Apple Watch.",
+	"com.apple.tvremoted":            "Provides Apple TV discovery and remote control.",
+	"com.apple.avatarsd":             "Maintains avatars and Memoji assets.",
+	"com.apple.stickersd":            "Maintains sticker packs and recently used stickers.",
+	"com.apple.sociallayerd":         "Supports social sharing and activity features.",
+	"com.apple.announced":            "Supports announced notifications and audio messages.",
+	"com.apple.navd":                 "Coordinates background navigation state.",
+	"com.apple.findmy.findmylocated": "Provides device location data to Find My.",
+
+	// Ads, Diagnostics & Telemetry
+	"com.apple.ap.adprivacyd":         "Maintains advertising privacy preferences and state.",
+	"com.apple.ap.promotedcontentd":   "Fetches and manages promoted Apple content.",
+	"com.apple.diagnosticextensionsd": "Runs system diagnostic data collectors.",
+	"com.apple.feedbackd":             "Collects and submits system feedback reports.",
+	"com.apple.rtcreportingd":         "Reports diagnostics for real-time communications.",
+	"com.apple.securityuploadd":       "Uploads security and trust telemetry.",
+	"com.apple.geoanalyticsd":         "Collects Maps and location-quality analytics.",
+	"com.apple.triald":                "Manages system feature experiments and configurations.",
+	"com.apple.followupd":             "Schedules account and setup follow-up notices.",
+	"com.apple.purplebuddy.budd":      "Maintains Setup Assistant completion state.",
+	"com.apple.devicecheckd":          "Provides DeviceCheck and app-attestation services.",
+
+	// Other Background Services
+	"com.apple.financed":                          "Provides Wallet transaction and finance services.",
+	"com.apple.passd":                             "Manages Wallet passes and Apple Pay state.",
+	"com.apple.merchantd":                         "Looks up merchant details for Wallet transactions.",
+	"com.apple.coreidvd":                          "Manages supported digital identity credentials.",
+	"com.apple.businessservicesd":                 "Supports Apple business messaging and services.",
+	"com.apple.deviceaccessd":                     "Coordinates app access to supported accessories.",
+	"com.apple.replicatord":                       "Replicates supported system data between services.",
+	"com.apple.linkd":                             "Indexes App Intents and shortcut suggestions.",
+	"com.apple.ind":                               "Receives background iCloud notifications.",
+	"com.apple.storagedatad":                      "Calculates storage usage shown by the system.",
+	"com.apple.StatusKitAgent":                    "Shares Focus, presence, and status between devices.",
+	"com.apple.countryd":                          "Determines regional availability for system features.",
+	"com.apple.mobileassetd":                      "Downloads and manages system asset packages.",
+	"com.apple.managedconfiguration.passcodenagd": "Enforces managed passcode requirements.",
+}
+
+func init() {
+	for i := range Categories {
+		Categories[i].ServiceDescriptions = make(map[string]string, len(Categories[i].Labels))
+		for _, label := range Categories[i].Labels {
+			Categories[i].ServiceDescriptions[label] = serviceDescriptionByLabel[label]
+		}
+	}
+}

--- a/slim.go
+++ b/slim.go
@@ -82,7 +82,7 @@ func status(ctx context.Context, udid string) (Status, map[string]bool, error) {
 }
 
 func statusForDevice(ctx context.Context, d Device) (Status, map[string]bool, error) {
-	managed := managedSet()
+	managed := slimmableSet()
 	st := Status{ManagedTotal: len(managed), Booted: d.State == "Booted"}
 	if !st.Booted {
 		return st, nil, fmt.Errorf("simulator must be booted to read its state (it is %s)", d.State)


### PR DESCRIPTION
## Summary

This follow-up makes service profiles easier to understand and tune without sacrificing a core iOS development workflow.

- Add search to the service sidebar. Search matches category copy, daemon labels, and plain-language daemon descriptions.
- Make every service category expandable and allow individual daemons to be kept enabled alongside the existing category toggles.
- Pass individual selections through the existing CLI `--keep` option and keep profile counts/status accurate.
- Add concise purpose summaries for all 170 controllable daemons, with tests that require complete and reasonably short copy.
- Keep `com.apple.sharingd` enabled in every slim profile. Disabling it saved only about 15 MB in testing but caused system share sheets to render blank, which breaks a core mobile-development workflow.
- Repair simulators slimmed by earlier versions: the next profile apply or restore re-enables `sharingd` automatically.
- Treat `sharingd` as visible but protected in the GUI so the behavior is transparent rather than silently omitted.
- Re-measure Sharing & Device Connectivity without `sharingd`. Three matched clean-boot pairs produced a 64.4 MiB median delta, reported as approximately 65 MB.
- Clamp cached shutdown status against the new 170-service total so older 171-service cache entries cannot display impossible counts.
- Update the README, architecture notes, and category-memory methodology.

## Why remove `sharingd` from slimming?

A slim profile should not break the ordinary UI workflows developers are trying to test. `sharingd` is responsible for populating system share sheets. The memory win was only about 15 MB, while the downside was a completely blank share sheet across apps. It now remains enabled and is included only in the managed repair allowlist so previously affected simulators recover automatically.

## Validation

- `make check`
- `go test -race -count=1 ./...`
- `make app`
- Verified service search by both daemon label and purpose text.
- Applied a per-daemon profile to an iOS 26.5 disposable clone (`169/170`), then restored full slim (`170/170`).
- Verified system share sheets populate with `sharingd` protected.
- Repeated connectivity RAM measurements across three alternating clean-boot pairs; no original simulator data was modified.
