### PR TITLE
profiles: accept a category ID to list its daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ service or disk changes so the copy can serve as a backup.
 ```sh
 simslim list             # simulators and their slim status
 simslim profiles         # what a slim boot turns off
+simslim profiles <id>    # the daemons in one category
 simslim on <udid>        # slim a simulator and reboot it slim
 simslim off <udid>       # put it back to stock
 simslim status <udid>    # how slim a booted simulator is

--- a/main.go
+++ b/main.go
@@ -151,8 +151,26 @@ func cmdProfiles(args []string) error {
 	if err != nil {
 		return err
 	}
-	if len(args) != 0 {
-		return fmt.Errorf("profiles takes no arguments")
+	if len(args) > 1 {
+		return fmt.Errorf("profiles takes at most one category ID (see `simslim profiles`)")
+	}
+	if len(args) == 1 {
+		c, ok := categoryByID(args[0])
+		if !ok {
+			return fmt.Errorf("unknown category %q (see `simslim profiles`)", args[0])
+		}
+		if jsonOutput {
+			return writeJSON(c)
+		}
+		fmt.Printf("%-14s %s\n", c.ID, c.Name)
+		fmt.Printf("               %s\n", c.Description)
+		fmt.Printf("               %d daemons · ~%d MB idle footprint when enabled\n", len(c.Labels), c.ApproxMemoryMB)
+		fmt.Printf("               When disabled: %s\n", c.Downside)
+		fmt.Println("\nDaemons:")
+		for _, l := range c.Labels {
+			fmt.Printf("  %s\n", l)
+		}
+		return nil
 	}
 	if jsonOutput {
 		return writeJSON(Categories)
@@ -164,6 +182,7 @@ func cmdProfiles(args []string) error {
 	}
 	fmt.Printf("\n%d daemons across %d categories. Deadlock-prone daemons are excluded and never touched.\n",
 		len(managedSet()), len(Categories))
+	fmt.Println("Run `simslim profiles <id>` to list a category's daemons.")
 	fmt.Println("Memory estimates are iOS 26.5 clean-boot measurements; they vary by runtime and workload and are not additive.")
 	return nil
 }
@@ -756,7 +775,8 @@ USAGE
 
 COMMANDS
   list                 List available simulators and their slim status
-  profiles             Show the daemon categories a slim boot disables
+  profiles [id]        Show the daemon categories a slim boot disables;
+                       pass a category ID to list that category's daemons
   on <udid>            Slim a simulator (persist disables + reboot slim)
       --except ids     Leave these categories enabled (comma-separated)
       --keep labels    Keep these individual daemons running (comma-separated)

--- a/main.go
+++ b/main.go
@@ -192,7 +192,6 @@ func cmdProfiles(args []string) error {
 	}
 	fmt.Printf("\n%d daemons across %d categories. Core workflow and deadlock-prone daemons are never disabled.\n",
 		len(slimmableSet()), len(Categories))
-	fmt.Println("Run `simslim profiles <id>` to list a category's daemons.")
 	fmt.Println("Memory estimates are iOS 26.5 clean-boot measurements; they vary by runtime and workload and are not additive.")
 	return nil
 }

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -59,6 +59,22 @@ func TestCategoriesHaveUserImpactMetadata(t *testing.T) {
 	}
 }
 
+func TestCategoryByID(t *testing.T) {
+	for _, c := range Categories {
+		got, ok := categoryByID(c.ID)
+		if !ok {
+			t.Errorf("categoryByID(%q) not found", c.ID)
+			continue
+		}
+		if got.ID != c.ID {
+			t.Errorf("categoryByID(%q) returned category %q", c.ID, got.ID)
+		}
+	}
+	if _, ok := categoryByID("nope"); ok {
+		t.Error("categoryByID(\"nope\") should not resolve an unknown ID")
+	}
+}
+
 func TestDelta(t *testing.T) {
 	managed := map[string]bool{"a": true, "b": true, "c": true}
 	cases := []struct {


### PR DESCRIPTION
## What

Extends `simslim profiles` to accept an optional category ID so you can see the actual launchd daemon labels in a category — previously only reachable via `--json | jq`.

- `simslim profiles` — unchanged category summary list (now with a one-line hint about the new form).
- `simslim profiles <id>` — that category's name, description, footprint, downside, and the full daemon label list.
- `simslim profiles <id> --json` — just that one `Category` object.
- Unknown IDs and extra arguments are rejected with a message pointing back to `simslim profiles` (matching the `on --except` error style).

## Why

Answering "what does the `siri` category actually turn off?" required piping JSON through `jq`. This makes it a first-class command.

## Notes

- Go + README only; no GUI/Swift changes, JSON structs unchanged, so the SwiftUI app is unaffected.
- Reuses the existing `categoryByID` helper for resolution.
- Added `TestCategoryByID` covering resolution of every category and rejection of unknown IDs.
- `go build`, `go test ./...`, and `go vet ./...` all pass; `gofmt` clean.