### PR TITLE
Auto-discover simulator device sets (parallel-testing clones)

### DIFF
--- a/disk_cleanup.go
+++ b/disk_cleanup.go
@@ -110,26 +110,18 @@ func diskCleanupCategoryByID(id string) (DiskCleanupCategory, bool) {
 	return DiskCleanupCategory{}, false
 }
 
+// simulatorDataDirectory returns the device's on-disk data directory, taken
+// straight from the dataPath simctl reports. It is validated as a real directory
+// before the disk commands touch it
+// every deletion is separately confined to it by clearDirectoryContents.
 func simulatorDataDirectory(ctx context.Context, udid string) (Device, string, error) {
-	device, err := findDevice(ctx, udid)
+	device, err := findDevice(ctx, udid, "")
 	if err != nil {
 		return Device{}, "", err
 	}
-	deviceSet := os.Getenv("SIMULATOR_DEVICE_SET_PATH")
-	if deviceSet == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return Device{}, "", fmt.Errorf("find home directory: %w", err)
-		}
-		deviceSet = filepath.Join(home, "Library", "Developer", "CoreSimulator", "Devices")
-	}
-	deviceSet, err = filepath.Abs(deviceSet)
-	if err != nil {
-		return Device{}, "", fmt.Errorf("resolve simulator device set: %w", err)
-	}
-	dataDirectory := filepath.Join(deviceSet, udid, "data")
-	if err := requireDescendant(deviceSet, dataDirectory); err != nil {
-		return Device{}, "", err
+	dataDirectory := device.DataPath
+	if dataDirectory == "" {
+		return Device{}, "", fmt.Errorf("simctl reported no data path for %s", udid)
 	}
 	info, err := os.Lstat(dataDirectory)
 	if err != nil {
@@ -137,9 +129,6 @@ func simulatorDataDirectory(ctx context.Context, udid string) (Device, string, e
 	}
 	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
 		return Device{}, "", fmt.Errorf("simulator data path is not a real directory: %s", dataDirectory)
-	}
-	if err := requireResolvedDescendant(deviceSet, dataDirectory); err != nil {
-		return Device{}, "", err
 	}
 	return device, dataDirectory, nil
 }
@@ -196,7 +185,7 @@ func cleanDeviceDisk(ctx context.Context, udid string, categoryIDs []string, pre
 
 	wasBooted := device.State == "Booted"
 	if wasBooted {
-		if _, err := shutdownIfBooted(ctx, udid); err != nil {
+		if _, _, err := shutdownIfBooted(ctx, udid); err != nil {
 			return DiskCleanupResult{}, err
 		}
 	}
@@ -204,7 +193,7 @@ func cleanDeviceDisk(ctx context.Context, udid string, categoryIDs []string, pre
 	result, cleanupErr := cleanDiskAt(udid, dataDirectory, categoryIDs)
 	result.WasBooted = wasBooted
 	if wasBooted && preserveBootState {
-		if bootErr := bootAndWait(ctx, udid); bootErr != nil {
+		if bootErr := bootAndWait(ctx, device.Set, udid); bootErr != nil {
 			if cleanupErr != nil {
 				return result, fmt.Errorf("%v; additionally could not restore boot state: %w", cleanupErr, bootErr)
 			}

--- a/main.go
+++ b/main.go
@@ -26,7 +26,16 @@ func main() {
 		os.Exit(2)
 	}
 
-	switch os.Args[1] {
+	args, err := extractDeviceSets(os.Args[1:])
+	if err != nil {
+		fatal(err.Error())
+	}
+	if len(args) == 0 {
+		usage()
+		os.Exit(2)
+	}
+
+	switch args[0] {
 	case "-v", "--version", "version":
 		fmt.Printf("simslim %s\n", version)
 		return
@@ -42,48 +51,89 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	var err error
-	switch os.Args[1] {
+	switch args[0] {
 	case "list":
-		err = cmdList(ctx, os.Args[2:])
+		err = cmdList(ctx, args[1:])
 	case "profiles":
-		err = cmdProfiles(os.Args[2:])
+		err = cmdProfiles(args[1:])
 	case "status":
-		err = cmdStatus(ctx, os.Args[2:])
+		err = cmdStatus(ctx, args[1:])
 	case "measure":
-		err = cmdMeasure(ctx, os.Args[2:])
+		err = cmdMeasure(ctx, args[1:])
 	case "size":
-		err = cmdSize(ctx, os.Args[2:])
+		err = cmdSize(ctx, args[1:])
 	case "disk-categories":
-		err = cmdDiskCategories(os.Args[2:])
+		err = cmdDiskCategories(args[1:])
 	case "disk-plan":
-		err = cmdDiskPlan(ctx, os.Args[2:])
+		err = cmdDiskPlan(ctx, args[1:])
 	case "disk-clean":
-		err = cmdDiskClean(ctx, os.Args[2:])
+		err = cmdDiskClean(ctx, args[1:])
 	case "clone":
-		err = cmdClone(ctx, os.Args[2:])
+		err = cmdClone(ctx, args[1:])
 	case "rename":
-		err = cmdRename(ctx, os.Args[2:])
+		err = cmdRename(ctx, args[1:])
 	case "boot":
-		err = cmdBoot(ctx, os.Args[2:])
+		err = cmdBoot(ctx, args[1:])
 	case "shutdown":
-		err = cmdShutdown(ctx, os.Args[2:])
+		err = cmdShutdown(ctx, args[1:])
 	case "erase":
-		err = cmdErase(ctx, os.Args[2:])
+		err = cmdErase(ctx, args[1:])
 	case "delete":
-		err = cmdDelete(ctx, os.Args[2:])
+		err = cmdDelete(ctx, args[1:])
 	case "on":
-		err = cmdOn(ctx, os.Args[2:])
+		err = cmdOn(ctx, args[1:])
 	case "off":
-		err = cmdOff(ctx, os.Args[2:])
+		err = cmdOff(ctx, args[1:])
 	default:
-		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", os.Args[1])
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", args[0])
 		usage()
 		os.Exit(2)
 	}
 	if err != nil {
 		fatal(err.Error())
 	}
+}
+
+// extractDeviceSets pulls the global --set flag (`--set value` or `--set=value`)
+// out of args and returns the remaining arguments, so the subcommand never sees
+// it. Each --set value is a comma-separated list of sets to scan; like the other
+// list flags, a repeated --set is last-wins rather than accumulated. Arguments
+// after a `--` terminator are passed through untouched, so a literal argument is
+// never mistaken for the flag.
+func extractDeviceSets(args []string) ([]string, error) {
+	remaining := make([]string, 0, len(args))
+	value := ""
+	seen := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			remaining = append(remaining, args[i:]...)
+			break
+		}
+		v, isSet := strings.CutPrefix(arg, "--set=")
+		if !isSet {
+			if arg != "--set" {
+				remaining = append(remaining, arg)
+				continue
+			}
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("--set requires a device set name (such as `testing`) or a path")
+			}
+			i++
+			v = args[i]
+		}
+		value, seen = v, true
+	}
+	if seen {
+		sets := splitList(value)
+		if len(sets) == 0 {
+			return nil, fmt.Errorf("--set requires a device set name (such as `testing`) or a path")
+		}
+		for _, set := range sets {
+			registerDeviceSet(set)
+		}
+	}
+	return remaining, nil
 }
 
 func cmdList(ctx context.Context, args []string) error {
@@ -137,7 +187,11 @@ func cmdList(ctx context.Context, args []string) error {
 		}
 		summaries = append(summaries, summary)
 		if !jsonOutput {
-			fmt.Printf("%s  %-22s iOS %-6s %s\n", d.UDID, truncate(d.Name, 22), d.OSVersion, tag)
+			line := fmt.Sprintf("%s  %-22s iOS %-6s %s", d.UDID, truncate(d.Name, 22), d.OSVersion, tag)
+			if d.Set != "" && d.Set != "default" {
+				line += "  (" + d.Set + ")"
+			}
+			fmt.Println(line)
 		}
 	}
 	if jsonOutput {
@@ -489,7 +543,7 @@ func cmdBoot(ctx context.Context, args []string) error {
 
 	// Resolve the exact device first so a simctl alias such as "all" can never
 	// enter the boot path, consistent with erase/delete.
-	device, err := findDevice(ctx, udid)
+	device, err := findDevice(ctx, udid, "")
 	if err != nil {
 		return err
 	}
@@ -510,7 +564,7 @@ func cmdBoot(ctx context.Context, args []string) error {
 	}
 	tctx, cancel := context.WithTimeout(ctx, bootTimeout)
 	defer cancel()
-	if err := bootAndWait(tctx, udid); err != nil {
+	if err := bootAndWait(tctx, device.Set, udid); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -532,7 +586,7 @@ func cmdShutdown(ctx context.Context, args []string) error {
 
 	// Resolve the exact device first so a simctl alias such as "all" can never
 	// enter the shutdown path, consistent with erase/delete.
-	device, err := findDevice(ctx, udid)
+	device, err := findDevice(ctx, udid, "")
 	if err != nil {
 		return err
 	}
@@ -547,10 +601,10 @@ func cmdShutdown(ctx context.Context, args []string) error {
 
 	tctx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 	defer cancel()
-	if err := shutdown(tctx, udid); err != nil {
+	if err := shutdown(tctx, device.Set, udid); err != nil {
 		return err
 	}
-	if err := waitShutdown(tctx, udid, shutdownTimeout); err != nil {
+	if err := waitShutdown(tctx, device.Set, udid, shutdownTimeout); err != nil {
 		return err
 	}
 	if jsonOutput {
@@ -572,10 +626,14 @@ func cmdOn(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	originallyShutdown, err := wasShutdown(ctx, udid, *preserveBootState)
+	// Resolve once: this pins the device's set (routing every simctl call below,
+	// including a parallel-testing clone), fails fast on an unknown UDID, and
+	// tells us whether to restore a shutdown state afterward.
+	device, err := findDevice(ctx, udid, "")
 	if err != nil {
 		return err
 	}
+	originallyShutdown := *preserveBootState && device.State == "Shutdown"
 
 	p := Profile{ExceptCategories: map[string]bool{}, Keep: map[string]bool{}}
 	for _, id := range splitList(*except) {
@@ -592,9 +650,9 @@ func cmdOn(ctx context.Context, args []string) error {
 	report := reporter(func(msg string) { fmt.Fprintln(os.Stderr, msg) })
 	tctx, cancel := context.WithTimeout(ctx, bootTimeout)
 	defer cancel()
-	changed, operationErr := enableSlim(tctx, udid, p, report)
+	changed, operationErr := enableSlim(tctx, device.Set, udid, p, report)
 	if originallyShutdown {
-		shutdownErr := returnToShutdown(ctx, udid)
+		shutdownErr := returnToShutdown(ctx, device.Set, udid)
 		if operationErr != nil && shutdownErr != nil {
 			return fmt.Errorf("%v; additionally could not restore original shutdown state: %w", operationErr, shutdownErr)
 		}
@@ -631,17 +689,18 @@ func cmdOff(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	originallyShutdown, err := wasShutdown(ctx, udid, *preserveBootState)
+	device, err := findDevice(ctx, udid, "")
 	if err != nil {
 		return err
 	}
+	originallyShutdown := *preserveBootState && device.State == "Shutdown"
 	fmt.Fprintf(os.Stderr, "Restoring %s to stock. The simulator will reboot to apply the changes.\n", udid)
 	report := reporter(func(msg string) { fmt.Fprintln(os.Stderr, msg) })
 	tctx, cancel := context.WithTimeout(ctx, bootTimeout)
 	defer cancel()
-	changed, operationErr := disableSlim(tctx, udid, report)
+	changed, operationErr := disableSlim(tctx, device.Set, udid, report)
 	if originallyShutdown {
-		shutdownErr := returnToShutdown(ctx, udid)
+		shutdownErr := returnToShutdown(ctx, device.Set, udid)
 		if operationErr != nil && shutdownErr != nil {
 			return fmt.Errorf("%v; additionally could not restore original shutdown state: %w", operationErr, shutdownErr)
 		}
@@ -668,24 +727,13 @@ func cmdOff(ctx context.Context, args []string) error {
 	return nil
 }
 
-func wasShutdown(ctx context.Context, udid string, inspect bool) (bool, error) {
-	if !inspect {
-		return false, nil
-	}
-	d, err := findDevice(ctx, udid)
-	if err != nil {
-		return false, err
-	}
-	return d.State == "Shutdown", nil
-}
-
-func returnToShutdown(ctx context.Context, udid string) error {
+func returnToShutdown(ctx context.Context, set, udid string) error {
 	shutdownCtx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 	defer cancel()
-	if err := shutdown(shutdownCtx, udid); err != nil {
+	if err := shutdown(shutdownCtx, set, udid); err != nil {
 		return fmt.Errorf("restore original shutdown state: %w", err)
 	}
-	if err := waitShutdown(shutdownCtx, udid, shutdownTimeout); err != nil {
+	if err := waitShutdown(shutdownCtx, set, udid, shutdownTimeout); err != nil {
 		return fmt.Errorf("restore original shutdown state: %w", err)
 	}
 	return nil
@@ -781,6 +829,11 @@ background daemons a simulator does not need.
 
 USAGE
   simslim <command> [args]
+
+GLOBAL OPTIONS
+  --set <name|path>    Also scan these device sets (comma-separated). The default
+                       and Xcode ` + "`testing`" + ` (parallel-testing) sets are always
+                       scanned; use this to add a set at a custom path.
 
 COMMANDS
   list                 List available simulators and their slim status

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSimctlArgsForSet(t *testing.T) {
+	t.Run("default set omits --set", func(t *testing.T) {
+		got := simctlArgsForSet("", "boot", "UDID")
+		want := []string{"simctl", "boot", "UDID"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("simctlArgsForSet() = %v, want %v", got, want)
+		}
+	})
+	t.Run("named set injects --set before the subcommand", func(t *testing.T) {
+		got := simctlArgsForSet("testing", "boot", "UDID")
+		want := []string{"simctl", "--set", "testing", "boot", "UDID"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("simctlArgsForSet() = %v, want %v", got, want)
+		}
+	})
+	t.Run("simctlArgs maps a set name to its --set token", func(t *testing.T) {
+		got := simctlArgs("testing", "list", "devices", "-j")
+		want := []string{"simctl", "--set", "testing", "list", "devices", "-j"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("simctlArgs() = %v, want %v", got, want)
+		}
+		if got := simctlArgs("default", "list"); !reflect.DeepEqual(got, []string{"simctl", "list"}) {
+			t.Errorf("simctlArgs(default) = %v, want no --set", got)
+		}
+	})
+}
+
+func TestDeviceSetToken(t *testing.T) {
+	if got := deviceSetToken("default"); got != "" {
+		t.Errorf("deviceSetToken(default) = %q, want empty", got)
+	}
+	if got := deviceSetToken("testing"); got != "testing" {
+		t.Errorf("deviceSetToken(testing) = %q, want testing", got)
+	}
+	if deviceSetToken("unknown-set") != "" {
+		t.Error("an unknown set name should fall back to the default token")
+	}
+}
+
+func TestExtractDeviceSets(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantArgs  []string
+		wantExtra []string // tokens registered beyond the well-known sets
+		wantError bool
+	}{
+		{name: "absent", args: []string{"list"}, wantArgs: []string{"list"}},
+		{name: "before command", args: []string{"--set", "/a", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/a"}},
+		{name: "after positional", args: []string{"on", "UDID", "--set", "/a"}, wantArgs: []string{"on", "UDID"}, wantExtra: []string{"/a"}},
+		{name: "equals form", args: []string{"list", "--set=/a"}, wantArgs: []string{"list"}, wantExtra: []string{"/a"}},
+		{name: "repeat is last-wins", args: []string{"--set", "/a", "--set", "/b", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/b"}},
+		{name: "comma-separated", args: []string{"--set", "/a,/b", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/a", "/b"}},
+		{name: "comma trims blanks", args: []string{"--set=/a, ,/b", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/a", "/b"}},
+		{name: "well-known not duplicated", args: []string{"--set", "testing", "list"}, wantArgs: []string{"list"}, wantExtra: nil},
+		{name: "terminator protects literal", args: []string{"rename", "UDID", "--", "--set"}, wantArgs: []string{"rename", "UDID", "--", "--set"}, wantExtra: nil},
+		{name: "missing value", args: []string{"list", "--set"}, wantError: true},
+		{name: "empty value", args: []string{"--set", "  ", "list"}, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extraDeviceSets = nil
+			defer func() { extraDeviceSets = nil }()
+			gotArgs, err := extractDeviceSets(tt.args)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("extractDeviceSets() error = %v, wantError %v", err, tt.wantError)
+			}
+			if tt.wantError {
+				return
+			}
+			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
+				t.Errorf("extractDeviceSets() args = %v, want %v", gotArgs, tt.wantArgs)
+			}
+			var gotExtra []string
+			for _, set := range extraDeviceSets {
+				gotExtra = append(gotExtra, set.token)
+			}
+			if !reflect.DeepEqual(gotExtra, tt.wantExtra) {
+				t.Errorf("registered extra sets = %v, want %v", gotExtra, tt.wantExtra)
+			}
+		})
+	}
+}
+
+func TestRegisterDeviceSetRoutes(t *testing.T) {
+	extraDeviceSets = nil
+	defer func() { extraDeviceSets = nil }()
+	registerDeviceSet("/custom/set")
+	// A registered set becomes discoverable like any other.
+	if deviceSetToken("/custom/set") != "/custom/set" {
+		t.Errorf("registered set not resolvable by name")
+	}
+	// A custom set's simctl args carry it as --set.
+	if got := simctlArgsForSet("/custom/set", "boot", "U"); !reflect.DeepEqual(got, []string{"simctl", "--set", "/custom/set", "boot", "U"}) {
+		t.Errorf("simctlArgsForSet(custom) = %v", got)
+	}
+}

--- a/simctl.go
+++ b/simctl.go
@@ -17,6 +17,58 @@ type Device struct {
 	Name      string `json:"name"`
 	State     string `json:"state"` // "Booted" or "Shutdown"
 	OSVersion string `json:"osVersion"`
+	Set       string `json:"set"`
+	DataPath  string `json:"-"`
+}
+
+type deviceSetInfo struct {
+	token string // "" for the default set; otherwise passed to `simctl --set`
+	name  string
+}
+
+// extraDeviceSets are sets named explicitly with --set
+var extraDeviceSets []deviceSetInfo
+
+func knownDeviceSets() []deviceSetInfo {
+	sets := []deviceSetInfo{
+		{token: "", name: "default"},
+		{token: "testing", name: "testing"},
+	}
+	return append(sets, extraDeviceSets...)
+}
+
+// registerDeviceSet adds a --set value to the scanned sets
+// ignoring any that duplicate an already-known token.
+func registerDeviceSet(value string) {
+	for _, set := range knownDeviceSets() {
+		if set.token == value {
+			return
+		}
+	}
+	extraDeviceSets = append(extraDeviceSets, deviceSetInfo{token: value, name: value})
+}
+
+func deviceSetToken(name string) string {
+	for _, set := range knownDeviceSets() {
+		if set.name == name {
+			return set.token
+		}
+	}
+	return ""
+}
+
+// simctlArgs targets the named device set; deviceSetToken maps "default" to the
+// empty --set token, "testing" and custom paths to themselves.
+func simctlArgs(set string, sub ...string) []string {
+	return simctlArgsForSet(deviceSetToken(set), sub...)
+}
+
+// The --set option must precede the subcommand.
+func simctlArgsForSet(token string, sub ...string) []string {
+	if token == "" {
+		return append([]string{"simctl"}, sub...)
+	}
+	return append([]string{"simctl", "--set", token}, sub...)
 }
 
 func xcrun(ctx context.Context, args ...string) ([]byte, error) {
@@ -27,8 +79,8 @@ func xcrun(ctx context.Context, args ...string) ([]byte, error) {
 	return out, nil
 }
 
-func listDevices(ctx context.Context) ([]Device, error) {
-	out, err := exec.CommandContext(ctx, "xcrun", "simctl", "list", "devices", "-j").Output()
+func listDevicesInSet(ctx context.Context, set deviceSetInfo) ([]Device, error) {
+	out, err := exec.CommandContext(ctx, "xcrun", simctlArgsForSet(set.token, "list", "devices", "-j")...).Output()
 	if err != nil {
 		return nil, fmt.Errorf("simctl list: %w", err)
 	}
@@ -38,6 +90,7 @@ func listDevices(ctx context.Context) ([]Device, error) {
 			Name        string `json:"name"`
 			State       string `json:"state"`
 			IsAvailable bool   `json:"isAvailable"`
+			DataPath    string `json:"dataPath"`
 		} `json:"devices"`
 	}
 	if err := json.Unmarshal(out, &parsed); err != nil {
@@ -52,8 +105,25 @@ func listDevices(ctx context.Context) ([]Device, error) {
 			if !d.IsAvailable {
 				continue
 			}
-			devices = append(devices, Device{UDID: d.UDID, Name: d.Name, State: d.State, OSVersion: osVersion(runtime)})
+			devices = append(devices, Device{UDID: d.UDID, Name: d.Name, State: d.State, OSVersion: osVersion(runtime), Set: set.name, DataPath: d.DataPath})
 		}
+	}
+	return devices, nil
+}
+
+// The default set is mandatory; a secondary set that cannot be listed (e.g. it
+// does not exist) is skipped rather than failing the whole listing.
+func listDevices(ctx context.Context) ([]Device, error) {
+	var devices []Device
+	for _, set := range knownDeviceSets() {
+		found, err := listDevicesInSet(ctx, set)
+		if err != nil {
+			if set.token == "" {
+				return nil, err
+			}
+			continue
+		}
+		devices = append(devices, found...)
 	}
 	return devices, nil
 }
@@ -67,14 +137,24 @@ func osVersion(runtime string) string {
 	return strings.ReplaceAll(runtime[i+len("iOS-"):], "-", ".")
 }
 
-func findDevice(ctx context.Context, udid string) (Device, error) {
-	devices, err := listDevices(ctx)
-	if err != nil {
-		return Device{}, err
-	}
-	for _, d := range devices {
-		if d.UDID == udid {
-			return d, nil
+// findDevice locates a simulator by UDID. An empty set searches every known set.
+// A non-empty set looks only there, so repeated lookups need not rescan.
+func findDevice(ctx context.Context, udid, set string) (Device, error) {
+	for _, s := range knownDeviceSets() {
+		if set != "" && s.name != set {
+			continue
+		}
+		found, err := listDevicesInSet(ctx, s)
+		if err != nil {
+			if s.token == "" {
+				return Device{}, err
+			}
+			continue
+		}
+		for _, d := range found {
+			if d.UDID == udid {
+				return d, nil
+			}
 		}
 	}
 	return Device{}, fmt.Errorf("no simulator with udid %s", udid)
@@ -116,22 +196,23 @@ func parseClonedUDID(output []byte) (string, error) {
 }
 
 // shutdownIfBooted resolves an exact device before any destructive command,
-// preventing simctl aliases such as "all" from entering these code paths.
-func shutdownIfBooted(ctx context.Context, udid string) (bool, error) {
-	device, err := findDevice(ctx, udid)
+// preventing simctl aliases such as "all" from entering these code paths. It
+// returns the device's set so the caller can target its own simctl call there.
+func shutdownIfBooted(ctx context.Context, udid string) (set string, wasBooted bool, err error) {
+	device, err := findDevice(ctx, udid, "")
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 	if device.State != "Booted" {
-		return false, nil
+		return device.Set, false, nil
 	}
-	if err := shutdown(ctx, udid); err != nil {
-		return true, err
+	if err := shutdown(ctx, device.Set, udid); err != nil {
+		return device.Set, true, err
 	}
-	if err := waitShutdown(ctx, udid, shutdownTimeout); err != nil {
-		return true, err
+	if err := waitShutdown(ctx, device.Set, udid, shutdownTimeout); err != nil {
+		return device.Set, true, err
 	}
-	return true, nil
+	return device.Set, true, nil
 }
 
 // cloneDevice temporarily shuts down a booted source because CoreSimulator can
@@ -141,7 +222,7 @@ func cloneDevice(ctx context.Context, udid, name string) (newUDID string, err er
 	if err != nil {
 		return "", err
 	}
-	wasBooted, err := shutdownIfBooted(ctx, udid)
+	set, wasBooted, err := shutdownIfBooted(ctx, udid)
 	if err != nil {
 		return "", err
 	}
@@ -149,7 +230,7 @@ func cloneDevice(ctx context.Context, udid, name string) (newUDID string, err er
 		defer func() {
 			restoreCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), bootTimeout)
 			defer cancel()
-			if restoreErr := bootAndWait(restoreCtx, udid); restoreErr != nil {
+			if restoreErr := bootAndWait(restoreCtx, set, udid); restoreErr != nil {
 				if err != nil {
 					err = fmt.Errorf("%v; additionally could not restore the source boot state: %w", err, restoreErr)
 				} else if newUDID != "" {
@@ -161,7 +242,7 @@ func cloneDevice(ctx context.Context, udid, name string) (newUDID string, err er
 		}()
 	}
 
-	out, err := xcrun(ctx, "simctl", "clone", udid, name)
+	out, err := xcrun(ctx, simctlArgs(set, "clone", udid, name)...)
 	if err != nil {
 		return "", err
 	}
@@ -169,49 +250,52 @@ func cloneDevice(ctx context.Context, udid, name string) (newUDID string, err er
 }
 
 func renameDevice(ctx context.Context, udid, name string) error {
-	if _, err := findDevice(ctx, udid); err != nil {
-		return err
-	}
-	name, err := normalizeSimulatorName(name)
+	device, err := findDevice(ctx, udid, "")
 	if err != nil {
 		return err
 	}
-	_, err = xcrun(ctx, "simctl", "rename", udid, name)
+	name, err = normalizeSimulatorName(name)
+	if err != nil {
+		return err
+	}
+	_, err = xcrun(ctx, simctlArgs(device.Set, "rename", udid, name)...)
 	return err
 }
 
 func eraseDevice(ctx context.Context, udid string) error {
-	if _, err := shutdownIfBooted(ctx, udid); err != nil {
+	set, _, err := shutdownIfBooted(ctx, udid)
+	if err != nil {
 		return err
 	}
-	_, err := xcrun(ctx, "simctl", "erase", udid)
+	_, err = xcrun(ctx, simctlArgs(set, "erase", udid)...)
 	return err
 }
 
 func deleteDevice(ctx context.Context, udid string) error {
-	if _, err := shutdownIfBooted(ctx, udid); err != nil {
+	set, _, err := shutdownIfBooted(ctx, udid)
+	if err != nil {
 		return err
 	}
-	_, err := xcrun(ctx, "simctl", "delete", udid)
+	_, err = xcrun(ctx, simctlArgs(set, "delete", udid)...)
 	return err
 }
 
 // bootAndWait boots the device (tolerating an already-booted one) and blocks on
 // bootstatus until its services are ready.
-func bootAndWait(ctx context.Context, udid string) error {
-	out, err := exec.CommandContext(ctx, "xcrun", "simctl", "boot", udid).CombinedOutput()
+func bootAndWait(ctx context.Context, set, udid string) error {
+	out, err := exec.CommandContext(ctx, "xcrun", simctlArgs(set, "boot", udid)...).CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(out))
 		if !strings.Contains(msg, "already booted") && !strings.Contains(msg, "current state: Booted") {
 			return fmt.Errorf("simctl boot: %w: %s", err, msg)
 		}
 	}
-	_, err = xcrun(ctx, "simctl", "bootstatus", udid, "-b")
+	_, err = xcrun(ctx, simctlArgs(set, "bootstatus", udid, "-b")...)
 	return err
 }
 
-func shutdown(ctx context.Context, udid string) error {
-	out, err := exec.CommandContext(ctx, "xcrun", "simctl", "shutdown", udid).CombinedOutput()
+func shutdown(ctx context.Context, set, udid string) error {
+	out, err := exec.CommandContext(ctx, "xcrun", simctlArgs(set, "shutdown", udid)...).CombinedOutput()
 	if err != nil {
 		if strings.Contains(string(out), "current state: Shutdown") {
 			return nil
@@ -223,9 +307,9 @@ func shutdown(ctx context.Context, udid string) error {
 
 // readDisabled returns the labels currently disabled in the device's system
 // domain. A label absent from the output is enabled.
-func readDisabled(ctx context.Context, udid string) (map[string]bool, error) {
-	out, err := exec.CommandContext(ctx, "xcrun", "simctl", "spawn", udid,
-		"launchctl", "print-disabled", "system").CombinedOutput()
+func readDisabled(ctx context.Context, set, udid string) (map[string]bool, error) {
+	out, err := exec.CommandContext(ctx, "xcrun", simctlArgs(set, "spawn", udid,
+		"launchctl", "print-disabled", "system")...).CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("launchctl print-disabled: %w: %s", err, strings.TrimSpace(string(out)))
 	}
@@ -265,11 +349,11 @@ func parseDisabled(output string) map[string]bool {
 // "DYLD_ROOT_PATH not set for simulator program". launchctl exits 0 even when it
 // prints the benign "switch to user/foreground" note, so a non-zero exit is a
 // real failure; failures are aggregated rather than aborting the whole profile.
-func applyDelta(ctx context.Context, udid string, toDisable, toEnable []string, report reporter) error {
+func applyDelta(ctx context.Context, set, udid string, toDisable, toEnable []string, report reporter) error {
 	total := len(toDisable) + len(toEnable)
 	run := func(action, label string) error {
-		out, err := exec.CommandContext(ctx, "xcrun", "simctl", "spawn", udid,
-			"launchctl", action, "system/"+label).CombinedOutput()
+		out, err := exec.CommandContext(ctx, "xcrun", simctlArgs(set, "spawn", udid,
+			"launchctl", action, "system/"+label)...).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%s %s: %w: %s", action, label, err, strings.TrimSpace(string(out)))
 		}
@@ -301,10 +385,10 @@ func applyDelta(ctx context.Context, udid string, toDisable, toEnable []string, 
 	return nil
 }
 
-func waitShutdown(ctx context.Context, udid string, timeout time.Duration) error {
+func waitShutdown(ctx context.Context, set, udid string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		d, err := findDevice(ctx, udid)
+		d, err := findDevice(ctx, udid, set)
 		if err != nil {
 			return err
 		}

--- a/slim.go
+++ b/slim.go
@@ -22,12 +22,12 @@ func (r reporter) report(msg string) {
 // actually changes. A running device is required to read/mutate launchctl, so
 // the device is booted first regardless. Each slow phase reports progress so the
 // caller can show the user that a multi-minute reconfigure is still working.
-func ensure(ctx context.Context, udid string, desired map[string]bool, report reporter) (changed bool, err error) {
+func ensure(ctx context.Context, set, udid string, desired map[string]bool, report reporter) (changed bool, err error) {
 	report.report("Booting the simulator (a first boot can take up to a minute)...")
-	if err := bootAndWait(ctx, udid); err != nil {
+	if err := bootAndWait(ctx, set, udid); err != nil {
 		return false, err
 	}
-	current, err := readDisabled(ctx, udid)
+	current, err := readDisabled(ctx, set, udid)
 	if err != nil {
 		return false, err
 	}
@@ -41,27 +41,27 @@ func ensure(ctx context.Context, udid string, desired map[string]bool, report re
 	if len(toEnable) > 0 {
 		report.report(fmt.Sprintf("Re-enabling %d background services...", len(toEnable)))
 	}
-	if err := applyDelta(ctx, udid, toDisable, toEnable, report); err != nil {
+	if err := applyDelta(ctx, set, udid, toDisable, toEnable, report); err != nil {
 		return true, err
 	}
 	report.report("Rebooting the simulator to apply the changes...")
-	if err := shutdown(ctx, udid); err != nil {
+	if err := shutdown(ctx, set, udid); err != nil {
 		return true, fmt.Errorf("shutdown before reboot: %w", err)
 	}
-	if err := waitShutdown(ctx, udid, shutdownTimeout); err != nil {
+	if err := waitShutdown(ctx, set, udid, shutdownTimeout); err != nil {
 		return true, err
 	}
-	return true, bootAndWait(ctx, udid)
+	return true, bootAndWait(ctx, set, udid)
 }
 
 // enableSlim disables the profile's daemons and boots the device slim.
-func enableSlim(ctx context.Context, udid string, p Profile, report reporter) (bool, error) {
-	return ensure(ctx, udid, p.desired(), report)
+func enableSlim(ctx context.Context, set, udid string, p Profile, report reporter) (bool, error) {
+	return ensure(ctx, set, udid, p.desired(), report)
 }
 
 // disableSlim re-enables every managed daemon, returning the device to stock.
-func disableSlim(ctx context.Context, udid string, report reporter) (bool, error) {
-	return ensure(ctx, udid, map[string]bool{}, report)
+func disableSlim(ctx context.Context, set, udid string, report reporter) (bool, error) {
+	return ensure(ctx, set, udid, map[string]bool{}, report)
 }
 
 // Status describes how slim a device currently is.
@@ -74,7 +74,7 @@ type Status struct {
 // status reports how slim a device is and returns the labels it currently has
 // disabled (nil when the device is not booted).
 func status(ctx context.Context, udid string) (Status, map[string]bool, error) {
-	d, err := findDevice(ctx, udid)
+	d, err := findDevice(ctx, udid, "")
 	if err != nil {
 		return Status{}, nil, err
 	}
@@ -87,7 +87,7 @@ func statusForDevice(ctx context.Context, d Device) (Status, map[string]bool, er
 	if !st.Booted {
 		return st, nil, fmt.Errorf("simulator must be booted to read its state (it is %s)", d.State)
 	}
-	disabled, err := readDisabled(ctx, d.UDID)
+	disabled, err := readDisabled(ctx, d.Set, d.UDID)
 	if err != nil {
 		return st, nil, err
 	}


### PR DESCRIPTION
Fixes #6.

## Problem

simslim only ever talked to the **default** CoreSimulator device set, so Xcode parallel-testing clones — which live in a separate set (`~/Library/Developer/XCTestDevices`, seen via `xcrun simctl --set testing list`) — were invisible:

- Clones were not listed by `simslim list`.
- `simslim on <clone-udid>` failed with `Invalid device or device pair` because the boot targeted the default set.

Reproduced directly: addressing a testing-set UDID without `--set` gives `Invalid device`, exactly the report.

## Fix

simctl has no way to enumerate device sets, so simslim probes the two well-known locations automatically — the default set and Xcode's `testing` clone set:

- **`list`** scans both and tags each row (and the JSON `set` field), so clones are visible with **no flag**.
- **Per-UDID commands** resolve which set a UDID lives in via `findDevice` and thread that set explicitly through every simctl call (`boot`, `shutdown`, `on`/`off`, `clone`, `rename`, `erase`, `delete`, `status`, disk commands). No hidden global — a resolved `Device` carries its set and callers pass `device.Set` down.
- **`--set <name|path>`** (global, comma-separated) registers additional sets to scan, for a device set at a custom path.
- **Disk commands** take the on-disk data directory straight from the `dataPath` simctl already reports, replacing the hand-rolled set→path reconstruction (and the hardcoded XCTestDevices path). Delete-safety is unchanged: `clearDirectoryContents` still confines every removal to that directory.

`measure` needs no change — it `pgrep`s the UDID-containing process path, which is set-independent.

## Safety / compatibility

- Default behavior for existing default-set commands is unchanged; the SwiftUI GUI (which never passes `--set`) is unaffected and no existing JSON fields changed (`set` is additive; `dataPath` is internal, `json:\"-\"`).
- Exact-UDID matching still prevents a simctl alias like `all` from entering a mutation.
- **Zero dependencies** — stdlib only.

## Tests

- `main_test.go` covers the `--set` parser (positions, `=` form, comma-separated, last-wins, terminator, errors), set registration, and the `simctl --set` arg construction.
- `make check` passes (go test, go vet, swift-format lint, build-app lint, plist lint).

## Verified on real simulators

Full lifecycle on a throwaway device: `clone` → `rename` → `list` → `boot` → `status` → `measure` → `on` (170 daemons disabled; **200→47 processes, 1.66 GB→228 MB**) → `off` (back to stock) → `size`/`disk-plan`/`disk-clean` → `shutdown` → `erase` → `delete`. Set routing (`list`/`size`/`disk-plan`/`boot`/`status`/`shutdown`) verified against a custom `--set` path as well.