### PR TITLE
refactor: parse CLI with urfave/cli/v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,9 +88,15 @@ The app is a thin front end that shells out to that bundled binary.
 
 ## Conventions
 
-- Flags may appear before or after positional args (e.g. `simslim on <udid> --except search`);
-  `parseInterspersedFlags` in `main.go` handles this, since stdlib `flag` stops at
-  the first positional. Use it for any command that takes both flags and a UDID.
+- CLI parsing uses `github.com/urfave/cli/v3` (the project's only dependency). The
+  command tree lives in `app.go` (`newApp`); each subcommand's `Action` is a
+  `cmd*` function in `main.go` that reads flags via `cmd.Bool/String(...)` and
+  positionals via `cmd.Args()`. Flags may appear before or after positional args
+  (e.g. `simslim on <udid> --except search`) — v3 parses flags anywhere by default.
+  `--set` is a global flag (inherited by every subcommand) registered in its flag
+  `Action`. `main.go` still owns `version`/`help`/no-args and the macOS-only guard
+  before handing off to the tree, and routes every command error through `fatal()`
+  for the stable `simslim: <msg>` (exit 1); unknown commands exit 2 with usage.
 - Two timeouts live in `main.go`: `shutdownTimeout` (30s) and `bootTimeout` (6min,
   because a first slim reconfigure boots twice).
 - Progress for multi-minute operations goes to **stderr** via the `reporter` type;

--- a/app.go
+++ b/app.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	cli "github.com/urfave/cli/v3"
+)
+
+// newApp builds the command tree. It handles subcommand dispatch, the global
+// --set flag, and per-command flag parsing.
+func newApp() *cli.Command {
+	jsonFlag := func() cli.Flag {
+		return &cli.BoolFlag{Name: "json", Usage: "print machine-readable JSON", OnlyOnce: true}
+	}
+	preserveBootStateFlag := func(usage string) cli.Flag {
+		return &cli.BoolFlag{Name: "preserve-boot-state", Usage: usage}
+	}
+
+	commands := []*cli.Command{
+		{Name: "list", Flags: []cli.Flag{jsonFlag()}, Action: cmdList},
+		{Name: "profiles", Flags: []cli.Flag{jsonFlag()}, Action: cmdProfiles},
+		{Name: "status", Flags: []cli.Flag{jsonFlag(), &cli.BoolFlag{Name: "dropped", Usage: "list the disabled daemons grouped by category"}}, Action: cmdStatus},
+		{Name: "measure", Flags: []cli.Flag{jsonFlag()}, Action: cmdMeasure},
+		{Name: "size", Flags: []cli.Flag{jsonFlag()}, Action: cmdSize},
+		{Name: "disk-categories", Flags: []cli.Flag{jsonFlag()}, Action: cmdDiskCategories},
+		{Name: "disk-plan", Flags: []cli.Flag{jsonFlag()}, Action: cmdDiskPlan},
+		{Name: "disk-clean", Flags: []cli.Flag{
+			jsonFlag(),
+			&cli.StringFlag{Name: "categories", Usage: "comma-separated cleanable disk category IDs"},
+			&cli.BoolFlag{Name: "confirm", Usage: "confirm permanent deletion"},
+			preserveBootStateFlag("reboot a simulator that was booted before cleanup"),
+		}, Action: cmdDiskClean},
+		{Name: "clone", Flags: []cli.Flag{jsonFlag()}, Action: cmdClone},
+		{Name: "rename", Flags: []cli.Flag{jsonFlag()}, Action: cmdRename},
+		{Name: "boot", Flags: []cli.Flag{jsonFlag()}, Action: cmdBoot},
+		{Name: "shutdown", Flags: []cli.Flag{jsonFlag()}, Action: cmdShutdown},
+		{Name: "erase", Flags: []cli.Flag{jsonFlag()}, Action: cmdErase},
+		{Name: "delete", Flags: []cli.Flag{jsonFlag()}, Action: cmdDelete},
+		{Name: "on", Flags: []cli.Flag{
+			&cli.StringFlag{Name: "except", Usage: "comma-separated category IDs to leave fully enabled (see `simslim profiles`)"},
+			&cli.StringFlag{Name: "keep", Usage: "comma-separated launchd labels to keep running"},
+			preserveBootStateFlag("return an initially shutdown simulator to shutdown after reconfiguration"),
+		}, Action: cmdOn},
+		{Name: "off", Flags: []cli.Flag{
+			preserveBootStateFlag("return an initially shutdown simulator to shutdown after reconfiguration"),
+		}, Action: cmdOff},
+	}
+
+	onUsageError := func(_ context.Context, _ *cli.Command, err error, _ bool) error {
+		if err != nil && strings.Contains(err.Error(), "flag needs an argument: --set") {
+			return fmt.Errorf("--set requires a device set name (such as `testing`) or a path")
+		}
+		return err
+	}
+	for _, c := range commands {
+		c.OnUsageError = onUsageError
+	}
+
+	return &cli.Command{
+		Name:         "simslim",
+		HideHelp:     true, // root help/usage is handled by main's usage()
+		HideVersion:  true, // version output is handled by main
+		OnUsageError: onUsageError,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "set",
+				Usage: "also scan these device sets (comma-separated name|path)",
+				Action: func(_ context.Context, _ *cli.Command, value string) error {
+					sets := splitList(value)
+					if len(sets) == 0 {
+						return fmt.Errorf("--set requires a device set name (such as `testing`) or a path")
+					}
+					for _, set := range sets {
+						registerDeviceSet(set)
+					}
+					return nil
+				},
+			},
+		},
+		Action: func(_ context.Context, cmd *cli.Command) error {
+			if args := cmd.Args().Slice(); len(args) > 0 {
+				fmt.Fprintf(os.Stderr, "unknown command %q\n\n", args[0])
+			}
+			usage()
+			os.Exit(2)
+			return nil
+		},
+		ExitErrHandler: func(_ context.Context, _ *cli.Command, _ error) {},
+		Commands:       commands,
+	}
+}

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"testing"
+)
+
+// runApp runs the CLI with stdout/stderr discarded so command output does not
+// pollute the test log. It uses `profiles`, which touches neither simctl nor the
+// macOS-only guard, to exercise flag and argument parsing through the real tree.
+func runApp(t *testing.T, args ...string) error {
+	t.Helper()
+	devnull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	if err != nil {
+		t.Fatalf("open %s: %v", os.DevNull, err)
+	}
+	defer devnull.Close()
+	oldStdout, oldStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = devnull, devnull
+	defer func() { os.Stdout, os.Stderr = oldStdout, oldStderr }()
+	return newApp().Run(context.Background(), append([]string{"simslim"}, args...))
+}
+
+// TestAppRegistersDeviceSets verifies the global --set flag registers the extra
+// device sets, whether it appears before or after the subcommand, in equals
+// form, comma-separated, or repeated (last-wins), and that a blank value errors.
+func TestAppRegistersDeviceSets(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantExtra []string // tokens registered beyond the well-known sets
+		wantError bool
+	}{
+		{name: "absent", args: []string{"profiles"}},
+		{name: "before command", args: []string{"--set", "/a", "profiles"}, wantExtra: []string{"/a"}},
+		{name: "after command", args: []string{"profiles", "--set", "/a"}, wantExtra: []string{"/a"}},
+		{name: "equals form", args: []string{"profiles", "--set=/a"}, wantExtra: []string{"/a"}},
+		{name: "comma-separated", args: []string{"--set", "/a,/b", "profiles"}, wantExtra: []string{"/a", "/b"}},
+		{name: "comma trims blanks", args: []string{"--set=/a, ,/b", "profiles"}, wantExtra: []string{"/a", "/b"}},
+		{name: "repeat is last-wins", args: []string{"--set", "/a", "--set", "/b", "profiles"}, wantExtra: []string{"/b"}},
+		{name: "well-known not duplicated", args: []string{"--set", "testing", "profiles"}},
+		{name: "blank value errors", args: []string{"--set", "  ", "profiles"}, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extraDeviceSets = nil
+			defer func() { extraDeviceSets = nil }()
+			err := runApp(t, tt.args...)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("Run(%v) error = %v, wantError %v", tt.args, err, tt.wantError)
+			}
+			var gotExtra []string
+			for _, set := range extraDeviceSets {
+				gotExtra = append(gotExtra, set.token)
+			}
+			if !reflect.DeepEqual(gotExtra, tt.wantExtra) {
+				t.Errorf("registered extra sets = %v, want %v", gotExtra, tt.wantExtra)
+			}
+		})
+	}
+}
+
+// TestAppFlagParsing covers per-command flag parsing: a flag may appear before
+// or after a positional argument, --json rejects duplicates, an unknown flag is
+// rejected, and an unknown positional fails validation.
+func TestAppFlagParsing(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantError bool
+	}{
+		{name: "json flag", args: []string{"profiles", "--json"}},
+		{name: "flag before positional", args: []string{"profiles", "--json", "siri"}},
+		{name: "flag after positional", args: []string{"profiles", "siri", "--json"}},
+		{name: "duplicate json rejected", args: []string{"profiles", "--json", "--json", "siri"}, wantError: true},
+		{name: "unknown flag rejected", args: []string{"profiles", "--nope"}, wantError: true},
+		{name: "unknown category rejected", args: []string{"profiles", "does-not-exist"}, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extraDeviceSets = nil
+			defer func() { extraDeviceSets = nil }()
+			err := runApp(t, tt.args...)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("Run(%v) error = %v, wantError %v", tt.args, err, tt.wantError)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/mobai-app/simslim
 
 go 1.26
+
+require github.com/urfave/cli/v3 v3.10.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/urfave/cli/v3 v3.10.1 h1:7Kx9H50hrHbRbyxgO1KP6/BcbiGRz0uYh5YyQ30JEEY=
+github.com/urfave/cli/v3 v3.10.1/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -10,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	cli "github.com/urfave/cli/v3"
 )
 
 // version is overwritten at build time via -ldflags "-X main.version=...".
@@ -26,16 +27,7 @@ func main() {
 		os.Exit(2)
 	}
 
-	args, err := extractDeviceSets(os.Args[1:])
-	if err != nil {
-		fatal(err.Error())
-	}
-	if len(args) == 0 {
-		usage()
-		os.Exit(2)
-	}
-
-	switch args[0] {
+	switch os.Args[1] {
 	case "-v", "--version", "version":
 		fmt.Printf("simslim %s\n", version)
 		return
@@ -51,97 +43,14 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	switch args[0] {
-	case "list":
-		err = cmdList(ctx, args[1:])
-	case "profiles":
-		err = cmdProfiles(args[1:])
-	case "status":
-		err = cmdStatus(ctx, args[1:])
-	case "measure":
-		err = cmdMeasure(ctx, args[1:])
-	case "size":
-		err = cmdSize(ctx, args[1:])
-	case "disk-categories":
-		err = cmdDiskCategories(args[1:])
-	case "disk-plan":
-		err = cmdDiskPlan(ctx, args[1:])
-	case "disk-clean":
-		err = cmdDiskClean(ctx, args[1:])
-	case "clone":
-		err = cmdClone(ctx, args[1:])
-	case "rename":
-		err = cmdRename(ctx, args[1:])
-	case "boot":
-		err = cmdBoot(ctx, args[1:])
-	case "shutdown":
-		err = cmdShutdown(ctx, args[1:])
-	case "erase":
-		err = cmdErase(ctx, args[1:])
-	case "delete":
-		err = cmdDelete(ctx, args[1:])
-	case "on":
-		err = cmdOn(ctx, args[1:])
-	case "off":
-		err = cmdOff(ctx, args[1:])
-	default:
-		fmt.Fprintf(os.Stderr, "unknown command %q\n\n", args[0])
-		usage()
-		os.Exit(2)
-	}
-	if err != nil {
+	if err := newApp().Run(ctx, os.Args); err != nil {
 		fatal(err.Error())
 	}
 }
 
-// extractDeviceSets pulls the global --set flag (`--set value` or `--set=value`)
-// out of args and returns the remaining arguments, so the subcommand never sees
-// it. Each --set value is a comma-separated list of sets to scan; like the other
-// list flags, a repeated --set is last-wins rather than accumulated. Arguments
-// after a `--` terminator are passed through untouched, so a literal argument is
-// never mistaken for the flag.
-func extractDeviceSets(args []string) ([]string, error) {
-	remaining := make([]string, 0, len(args))
-	value := ""
-	seen := false
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
-			remaining = append(remaining, args[i:]...)
-			break
-		}
-		v, isSet := strings.CutPrefix(arg, "--set=")
-		if !isSet {
-			if arg != "--set" {
-				remaining = append(remaining, arg)
-				continue
-			}
-			if i+1 >= len(args) {
-				return nil, fmt.Errorf("--set requires a device set name (such as `testing`) or a path")
-			}
-			i++
-			v = args[i]
-		}
-		value, seen = v, true
-	}
-	if seen {
-		sets := splitList(value)
-		if len(sets) == 0 {
-			return nil, fmt.Errorf("--set requires a device set name (such as `testing`) or a path")
-		}
-		for _, set := range sets {
-			registerDeviceSet(set)
-		}
-	}
-	return remaining, nil
-}
-
-func cmdList(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	if len(args) != 0 {
+func cmdList(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	if cmd.Args().Len() != 0 {
 		return fmt.Errorf("list takes no arguments")
 	}
 	devices, err := listDevices(ctx)
@@ -200,11 +109,9 @@ func cmdList(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdProfiles(args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
+func cmdProfiles(_ context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	args := cmd.Args().Slice()
 	if len(args) > 1 {
 		return fmt.Errorf("profiles takes at most one category ID (see `simslim profiles`)")
 	}
@@ -250,17 +157,10 @@ func cmdProfiles(args []string) error {
 	return nil
 }
 
-func cmdStatus(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	fs := flag.NewFlagSet("status", flag.ContinueOnError)
-	showDropped := fs.Bool("dropped", false, "list the disabled daemons grouped by category")
-	if err := parseInterspersedFlags(fs, args); err != nil {
-		return err
-	}
-	udid, err := oneUDID(fs.Args())
+func cmdStatus(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	showDropped := cmd.Bool("dropped")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -276,14 +176,14 @@ func cmdStatus(ctx context.Context, args []string) error {
 		verdict = "partially slim"
 	}
 	var dropped []DroppedCategory
-	if *showDropped {
+	if showDropped {
 		dropped = droppedCategories(disabled)
 	}
 	if jsonOutput {
 		return writeJSON(StatusOutput{Status: st, Verdict: verdict, Dropped: dropped})
 	}
 	fmt.Printf("%s: %d/%d managed daemons disabled (%s)\n", udid, st.ManagedDisabled, st.ManagedTotal, verdict)
-	if *showDropped {
+	if showDropped {
 		if len(dropped) == 0 {
 			fmt.Println("  Nothing dropped; every managed daemon is enabled.")
 		}
@@ -297,12 +197,9 @@ func cmdStatus(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdMeasure(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	udid, err := oneUDID(args)
+func cmdMeasure(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -317,12 +214,9 @@ func cmdMeasure(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdSize(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	udid, err := oneUDID(args)
+func cmdSize(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -339,12 +233,9 @@ func cmdSize(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdDiskCategories(args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	if len(args) != 0 {
+func cmdDiskCategories(_ context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	if cmd.Args().Len() != 0 {
 		return fmt.Errorf("disk-categories takes no arguments")
 	}
 	if jsonOutput {
@@ -361,12 +252,9 @@ func cmdDiskCategories(args []string) error {
 	return nil
 }
 
-func cmdDiskPlan(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	udid, err := oneUDID(args)
+func cmdDiskPlan(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -396,32 +284,22 @@ func cmdDiskPlan(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdDiskClean(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
+func cmdDiskClean(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
-	fs := flag.NewFlagSet("disk-clean", flag.ContinueOnError)
-	categories := fs.String("categories", "", "comma-separated cleanable disk category IDs")
-	confirmed := fs.Bool("confirm", false, "confirm permanent deletion")
-	preserveBootState := fs.Bool("preserve-boot-state", false, "reboot a simulator that was booted before cleanup")
-	if err := parseInterspersedFlags(fs, args); err != nil {
-		return err
-	}
-	udid, err := oneUDID(fs.Args())
-	if err != nil {
-		return err
-	}
-	if !*confirmed {
+	if !cmd.Bool("confirm") {
 		return fmt.Errorf("disk-clean permanently deletes data; pass --confirm after reviewing `simslim disk-plan %s`", udid)
 	}
-	categoryIDs := splitList(*categories)
+	categoryIDs := splitList(cmd.String("categories"))
 	if _, err := validateDiskCleanupSelection(categoryIDs); err != nil {
 		return err
 	}
 	tctx, cancel := context.WithTimeout(ctx, bootTimeout)
 	defer cancel()
-	result, err := cleanDeviceDisk(tctx, udid, categoryIDs, *preserveBootState)
+	result, err := cleanDeviceDisk(tctx, udid, categoryIDs, cmd.Bool("preserve-boot-state"))
 	if err != nil {
 		return err
 	}
@@ -432,11 +310,9 @@ func cmdDiskClean(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdClone(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
+func cmdClone(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	args := cmd.Args().Slice()
 	if len(args) != 2 {
 		return fmt.Errorf("clone expects a simulator UDID and a new name")
 	}
@@ -459,11 +335,9 @@ func cmdClone(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdRename(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
+func cmdRename(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	args := cmd.Args().Slice()
 	if len(args) != 2 {
 		return fmt.Errorf("rename expects a simulator UDID and a new name")
 	}
@@ -485,12 +359,9 @@ func cmdRename(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdErase(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	udid, err := oneUDID(args)
+func cmdErase(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -508,12 +379,9 @@ func cmdErase(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdDelete(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	udid, err := oneUDID(args)
+func cmdDelete(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -531,12 +399,9 @@ func cmdDelete(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdBoot(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	udid, err := oneUDID(args)
+func cmdBoot(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -574,12 +439,9 @@ func cmdBoot(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdShutdown(ctx context.Context, args []string) error {
-	jsonOutput, args, err := jsonOption(args)
-	if err != nil {
-		return err
-	}
-	udid, err := oneUDID(args)
+func cmdShutdown(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -614,15 +476,9 @@ func cmdShutdown(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdOn(ctx context.Context, args []string) error {
-	fs := flag.NewFlagSet("on", flag.ContinueOnError)
-	except := fs.String("except", "", "comma-separated category IDs to leave fully enabled (see `simslim profiles`)")
-	keep := fs.String("keep", "", "comma-separated launchd labels to keep running")
-	preserveBootState := fs.Bool("preserve-boot-state", false, "return a shutdown simulator to shutdown after reconfiguration")
-	if err := parseInterspersedFlags(fs, args); err != nil {
-		return err
-	}
-	udid, err := oneUDID(fs.Args())
+func cmdOn(ctx context.Context, cmd *cli.Command) error {
+	preserveBootState := cmd.Bool("preserve-boot-state")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -633,16 +489,16 @@ func cmdOn(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	originallyShutdown := *preserveBootState && device.State == "Shutdown"
+	originallyShutdown := preserveBootState && device.State == "Shutdown"
 
 	p := Profile{ExceptCategories: map[string]bool{}, Keep: map[string]bool{}}
-	for _, id := range splitList(*except) {
+	for _, id := range splitList(cmd.String("except")) {
 		if _, ok := categoryByID(id); !ok {
 			return fmt.Errorf("unknown category %q (see `simslim profiles`)", id)
 		}
 		p.ExceptCategories[id] = true
 	}
-	for _, l := range splitList(*keep) {
+	for _, l := range splitList(cmd.String("keep")) {
 		p.Keep[l] = true
 	}
 
@@ -679,13 +535,9 @@ func cmdOn(ctx context.Context, args []string) error {
 	return nil
 }
 
-func cmdOff(ctx context.Context, args []string) error {
-	fs := flag.NewFlagSet("off", flag.ContinueOnError)
-	preserveBootState := fs.Bool("preserve-boot-state", false, "return a shutdown simulator to shutdown after reconfiguration")
-	if err := parseInterspersedFlags(fs, args); err != nil {
-		return err
-	}
-	udid, err := oneUDID(fs.Args())
+func cmdOff(ctx context.Context, cmd *cli.Command) error {
+	preserveBootState := cmd.Bool("preserve-boot-state")
+	udid, err := oneUDID(cmd.Args().Slice())
 	if err != nil {
 		return err
 	}
@@ -693,7 +545,7 @@ func cmdOff(ctx context.Context, args []string) error {
 	if err != nil {
 		return err
 	}
-	originallyShutdown := *preserveBootState && device.State == "Shutdown"
+	originallyShutdown := preserveBootState && device.State == "Shutdown"
 	fmt.Fprintf(os.Stderr, "Restoring %s to stock. The simulator will reboot to apply the changes.\n", udid)
 	report := reporter(func(msg string) { fmt.Fprintln(os.Stderr, msg) })
 	tctx, cancel := context.WithTimeout(ctx, bootTimeout)
@@ -744,44 +596,6 @@ func oneUDID(args []string) (string, error) {
 		return "", fmt.Errorf("expected exactly one simulator UDID (see `simslim list`)")
 	}
 	return args[0], nil
-}
-
-// parseInterspersedFlags accepts options before or after positional arguments.
-// The standard flag package stops at the first positional argument, which is
-// surprising for documented forms such as `simslim on <udid> --except search`.
-func parseInterspersedFlags(fs *flag.FlagSet, args []string) error {
-	var optionArgs []string
-	var positionalArgs []string
-	optionsEnabled := true
-
-	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if optionsEnabled && arg == "--" {
-			optionsEnabled = false
-			continue
-		}
-		if !optionsEnabled || arg == "-" || !strings.HasPrefix(arg, "-") {
-			positionalArgs = append(positionalArgs, arg)
-			continue
-		}
-
-		optionArgs = append(optionArgs, arg)
-		nameAndValue := strings.TrimLeft(arg, "-")
-		name, _, hasInlineValue := strings.Cut(nameAndValue, "=")
-		registered := fs.Lookup(name)
-		if registered == nil || hasInlineValue {
-			continue
-		}
-		if boolFlag, ok := registered.Value.(interface{ IsBoolFlag() bool }); ok && boolFlag.IsBoolFlag() {
-			continue
-		}
-		if i+1 < len(args) {
-			i++
-			optionArgs = append(optionArgs, args[i])
-		}
-	}
-
-	return fs.Parse(append(optionArgs, positionalArgs...))
 }
 
 func splitList(s string) []string {

--- a/main_test.go
+++ b/main_test.go
@@ -44,52 +44,6 @@ func TestDeviceSetToken(t *testing.T) {
 	}
 }
 
-func TestExtractDeviceSets(t *testing.T) {
-	tests := []struct {
-		name      string
-		args      []string
-		wantArgs  []string
-		wantExtra []string // tokens registered beyond the well-known sets
-		wantError bool
-	}{
-		{name: "absent", args: []string{"list"}, wantArgs: []string{"list"}},
-		{name: "before command", args: []string{"--set", "/a", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/a"}},
-		{name: "after positional", args: []string{"on", "UDID", "--set", "/a"}, wantArgs: []string{"on", "UDID"}, wantExtra: []string{"/a"}},
-		{name: "equals form", args: []string{"list", "--set=/a"}, wantArgs: []string{"list"}, wantExtra: []string{"/a"}},
-		{name: "repeat is last-wins", args: []string{"--set", "/a", "--set", "/b", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/b"}},
-		{name: "comma-separated", args: []string{"--set", "/a,/b", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/a", "/b"}},
-		{name: "comma trims blanks", args: []string{"--set=/a, ,/b", "list"}, wantArgs: []string{"list"}, wantExtra: []string{"/a", "/b"}},
-		{name: "well-known not duplicated", args: []string{"--set", "testing", "list"}, wantArgs: []string{"list"}, wantExtra: nil},
-		{name: "terminator protects literal", args: []string{"rename", "UDID", "--", "--set"}, wantArgs: []string{"rename", "UDID", "--", "--set"}, wantExtra: nil},
-		{name: "missing value", args: []string{"list", "--set"}, wantError: true},
-		{name: "empty value", args: []string{"--set", "  ", "list"}, wantError: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			extraDeviceSets = nil
-			defer func() { extraDeviceSets = nil }()
-			gotArgs, err := extractDeviceSets(tt.args)
-			if (err != nil) != tt.wantError {
-				t.Fatalf("extractDeviceSets() error = %v, wantError %v", err, tt.wantError)
-			}
-			if tt.wantError {
-				return
-			}
-			if !reflect.DeepEqual(gotArgs, tt.wantArgs) {
-				t.Errorf("extractDeviceSets() args = %v, want %v", gotArgs, tt.wantArgs)
-			}
-			var gotExtra []string
-			for _, set := range extraDeviceSets {
-				gotExtra = append(gotExtra, set.token)
-			}
-			if !reflect.DeepEqual(gotExtra, tt.wantExtra) {
-				t.Errorf("registered extra sets = %v, want %v", gotExtra, tt.wantExtra)
-			}
-		})
-	}
-}
-
 func TestRegisterDeviceSetRoutes(t *testing.T) {
 	extraDeviceSets = nil
 	defer func() { extraDeviceSets = nil }()

--- a/output.go
+++ b/output.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 )
 
@@ -50,23 +49,4 @@ func writeJSON(value any) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(value)
-}
-
-// jsonOption removes one optional --json flag while rejecting duplicates.
-// Keeping this independent of flag.FlagSet lets callers put --json before or
-// after a UDID, which is friendlier for programmatic use.
-func jsonOption(args []string) (bool, []string, error) {
-	jsonOutput := false
-	remaining := make([]string, 0, len(args))
-	for _, arg := range args {
-		if arg != "--json" {
-			remaining = append(remaining, arg)
-			continue
-		}
-		if jsonOutput {
-			return false, nil, fmt.Errorf("--json may only be specified once")
-		}
-		jsonOutput = true
-	}
-	return jsonOutput, remaining, nil
 }

--- a/output_test.go
+++ b/output_test.go
@@ -1,89 +1,8 @@
 package main
 
 import (
-	"flag"
-	"io"
-	"reflect"
 	"testing"
 )
-
-func TestJSONOption(t *testing.T) {
-	tests := []struct {
-		name      string
-		args      []string
-		wantJSON  bool
-		wantArgs  []string
-		wantError bool
-	}{
-		{name: "absent", args: []string{"abc"}, wantArgs: []string{"abc"}},
-		{name: "before udid", args: []string{"--json", "abc"}, wantJSON: true, wantArgs: []string{"abc"}},
-		{name: "after udid", args: []string{"abc", "--json"}, wantJSON: true, wantArgs: []string{"abc"}},
-		{name: "duplicate", args: []string{"--json", "--json"}, wantError: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotJSON, gotArgs, err := jsonOption(tt.args)
-			if (err != nil) != tt.wantError {
-				t.Fatalf("jsonOption() error = %v, wantError %v", err, tt.wantError)
-			}
-			if gotJSON != tt.wantJSON {
-				t.Errorf("jsonOption() json = %v, want %v", gotJSON, tt.wantJSON)
-			}
-			if len(gotArgs) != len(tt.wantArgs) {
-				t.Fatalf("jsonOption() args = %v, want %v", gotArgs, tt.wantArgs)
-			}
-			for i := range gotArgs {
-				if gotArgs[i] != tt.wantArgs[i] {
-					t.Errorf("jsonOption() args = %v, want %v", gotArgs, tt.wantArgs)
-				}
-			}
-		})
-	}
-}
-
-func TestParseInterspersedFlags(t *testing.T) {
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	categories := fs.String("categories", "", "")
-	confirmed := fs.Bool("confirm", false, "")
-	preserveBootState := fs.Bool("preserve-boot-state", false, "")
-
-	args := []string{
-		"TEST-UDID",
-		"--confirm",
-		"--categories", "caches,logs",
-		"--preserve-boot-state=true",
-	}
-	if err := parseInterspersedFlags(fs, args); err != nil {
-		t.Fatalf("parseInterspersedFlags() error = %v", err)
-	}
-	if got, want := fs.Args(), []string{"TEST-UDID"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("positionals = %v, want %v", got, want)
-	}
-	if *categories != "caches,logs" || !*confirmed || !*preserveBootState {
-		t.Fatalf(
-			"flags = categories %q, confirm %v, preserve %v",
-			*categories, *confirmed, *preserveBootState,
-		)
-	}
-}
-
-func TestParseInterspersedFlagsHonorsSeparator(t *testing.T) {
-	fs := flag.NewFlagSet("test", flag.ContinueOnError)
-	fs.SetOutput(io.Discard)
-	confirmed := fs.Bool("confirm", false, "")
-
-	if err := parseInterspersedFlags(fs, []string{"--confirm", "device", "--", "--literal"}); err != nil {
-		t.Fatalf("parseInterspersedFlags() error = %v", err)
-	}
-	if !*confirmed {
-		t.Fatal("confirm flag was not parsed")
-	}
-	if got, want := fs.Args(), []string{"device", "--literal"}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("positionals = %v, want %v", got, want)
-	}
-}
 
 func TestTruncatePreservesUnicode(t *testing.T) {
 	if got, want := truncate("模拟器名称", 4), "模拟器…"; got != want {


### PR DESCRIPTION
## What

Replace the hand-rolled argument handling with the [`urfave/cli/v3`](https://github.com/urfave/cli) command tree — the project's only dependency, with no runtime transitive deps.

Removed:
- the 16-case `switch os.Args[1]` dispatch
- `parseInterspersedFlags` (flags before/after positionals — v3 does this natively)
- `jsonOption` (now a per-command `--json` flag)
- `extractDeviceSets` (now a global `--set` flag registered in its flag `Action`)

Net: `main.go` shed ~240 lines. The command tree lives in the new `app.go` (`newApp`); each subcommand's `Action` is a `cmd*` function in `main.go` that reads flags via `cmd.Bool/String(...)` and positionals via `cmd.Args()`.

## Surface is 1-to-1

Same commands, flags, arguments, JSON output, and error handling. Verified by diffing **45 invocations** (errors, usage, version, flag forms, `--set` variants, read-only commands) against a binary built from the pre-refactor source. Preserved exactly:

- `simslim: <msg>` on errors (exit 1); `unknown command "x"` + usage (exit 2)
- verbatim root `usage()` text; `simslim <version>` format
- `--set` semantics (comma-separated, last-wins) and its specific missing-value message
- flags accepted before or after positional args

`version`, `help`, and the macOS guard stay in `main`.

### Two intentional deltas
- **`--` terminator** (`rename X -- --set`): now standard end-of-flags semantics, so a dash-prefixed rename target works; the old code spuriously errored.
- **Duplicate `--json`**: still rejected (exit 1), but with the library's wording rather than the old custom string.

## Tests

Unit tests for the deleted helpers are replaced by `app_test.go`, which drives the real `newApp()` through `Run` (using `profiles`, which needs neither simctl nor macOS) to cover `--set` registration and interspersed/duplicate/unknown-flag parsing. `go test`, `go vet`, and `gofmt` all pass.