### PR TITLE
feat: add slim profiles — --profile files and an interactive builder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,10 @@ which simslim may only repair back to enabled; these are **the only labels the
 tool may ever disable or enable.** Anything outside those sets is never touched.
 `service_descriptions.go` supplies the short per-daemon explanations shown by
 the GUI; its coverage and length are enforced in `profiles_test.go`.
+`profile_file.go` loads a committed JSON profile (`simslim on --profile <path>`)
+whose `except`/`keep` arrays mirror the flags of the same name, validates it
+against the allowlist, and resolves it to a `Profile`; it also holds the
+dependency-free `profile` command's wizard that assembles one interactively.
 `slim.go`'s `ensure()` boots the device, reads its currently
 disabled labels, computes a `delta` against the desired set, and applies the
 changes with `launchctl disable/enable` run inside the simulator via

--- a/README.md
+++ b/README.md
@@ -114,6 +114,35 @@ Or keep one specific daemon, like push notifications:
 simslim on <udid> --keep com.apple.apsd
 ```
 
+### Profile files
+
+For a repeatable setup, commit a JSON profile alongside your project and apply it
+per run. A `ci.json` and a `dev.json` can slim differently for each purpose:
+
+```json
+{
+  "name": "ci",
+  "description": "UI test runs",
+  "except": ["search", "store"],
+  "keep": ["com.apple.apsd"]
+}
+```
+
+```sh
+simslim on <udid> --profile ci.json
+```
+
+`except` and `keep` mirror the flags of the same name; `name` and `description`
+are for whoever reads the file. Unknown fields, unknown category IDs, and labels
+no category disables are rejected, so a typo fails loudly. `--profile` is the
+single source of truth for its run and cannot be combined with `--except` or
+`--keep`.
+
+To build one interactively, run `simslim profile ci.json`: name it, then use the
+arrow keys and space to tick whole features to keep enabled, or press `→` to open
+a feature and keep individual daemons within it. Point it at a directory to save
+`<name>.json` there, or omit the path to print to stdout.
+
 ## How it works
 
 `simslim on` writes persistent `launchctl disable` entries for the chosen daemons into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only daemons that are safe to disable. Core workflow services such as `sharingd`, plus the handful that wedge a simulator when turned off, are left running.

--- a/app.go
+++ b/app.go
@@ -22,6 +22,7 @@ func newApp() *cli.Command {
 	commands := []*cli.Command{
 		{Name: "list", Flags: []cli.Flag{jsonFlag()}, Action: cmdList},
 		{Name: "profiles", Flags: []cli.Flag{jsonFlag()}, Action: cmdProfiles},
+		{Name: "profile", Action: cmdNewProfile},
 		{Name: "status", Flags: []cli.Flag{jsonFlag(), &cli.BoolFlag{Name: "dropped", Usage: "list the disabled daemons grouped by category"}}, Action: cmdStatus},
 		{Name: "measure", Flags: []cli.Flag{jsonFlag()}, Action: cmdMeasure},
 		{Name: "size", Flags: []cli.Flag{jsonFlag()}, Action: cmdSize},
@@ -40,6 +41,7 @@ func newApp() *cli.Command {
 		{Name: "erase", Flags: []cli.Flag{jsonFlag()}, Action: cmdErase},
 		{Name: "delete", Flags: []cli.Flag{jsonFlag()}, Action: cmdDelete},
 		{Name: "on", Flags: []cli.Flag{
+			&cli.StringFlag{Name: "profile", Usage: "apply a JSON profile file (mutually exclusive with --except/--keep)"},
 			&cli.StringFlag{Name: "except", Usage: "comma-separated category IDs to leave fully enabled (see `simslim profiles`)"},
 			&cli.StringFlag{Name: "keep", Usage: "comma-separated launchd labels to keep running"},
 			preserveBootStateFlag("return an initially shutdown simulator to shutdown after reconfiguration"),

--- a/main.go
+++ b/main.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -154,6 +156,66 @@ func cmdProfiles(_ context.Context, cmd *cli.Command) error {
 	fmt.Printf("\n%d daemons across %d categories. Core workflow and deadlock-prone daemons are never disabled.\n",
 		len(slimmableSet()), len(Categories))
 	fmt.Println("Memory estimates are iOS 26.5 clean-boot measurements; they vary by runtime and workload and are not additive.")
+	return nil
+}
+
+func cmdNewProfile(_ context.Context, cmd *cli.Command) error {
+	args := cmd.Args().Slice()
+	if len(args) > 1 {
+		return fmt.Errorf("profile takes an optional output path")
+	}
+	var dest string
+	if len(args) == 1 {
+		dest = args[0]
+	}
+
+	intoDir := false
+	if dest != "" {
+		if info, err := os.Stat(dest); err == nil {
+			if info.IsDir() {
+				intoDir = true
+			} else {
+				return fmt.Errorf("refusing to overwrite %s", dest)
+			}
+		}
+	}
+	if !stdinIsTerminal() {
+		return fmt.Errorf("profile is interactive; run it in a terminal")
+	}
+
+	sp, err := runProfileWizard(os.Stdin, os.Stderr, enterRawMode)
+	if err != nil {
+		if errors.Is(err, errWizardCancelled) {
+			fmt.Fprintln(os.Stderr, "Cancelled; no profile written.")
+			return nil
+		}
+		return err
+	}
+	data, err := marshalProfile(sp)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stderr, "Keeping %d feature(s) fully enabled and %d individual daemon(s); slimming the rest.\n", len(sp.Except), len(sp.Keep))
+
+	path := dest
+	if intoDir {
+		path = filepath.Join(dest, profileFileName(sp.Name))
+	}
+	if path == "" {
+		_, err = os.Stdout.Write(data)
+		return err
+	}
+
+	if intoDir {
+		if _, err := os.Stat(path); err == nil {
+			os.Stdout.Write(data)
+			return fmt.Errorf("%s already exists; printed the profile above instead of overwriting it", path)
+		}
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	fmt.Fprintf(os.Stderr, "Wrote %s. Apply it with `simslim on <udid> --profile %s`.\n", path, path)
 	return nil
 }
 
@@ -482,6 +544,11 @@ func cmdOn(ctx context.Context, cmd *cli.Command) error {
 	if err != nil {
 		return err
 	}
+
+	p, err := buildProfile(cmd.String("profile"), cmd.String("except"), cmd.String("keep"))
+	if err != nil {
+		return err
+	}
 	// Resolve once: this pins the device's set (routing every simctl call below,
 	// including a parallel-testing clone), fails fast on an unknown UDID, and
 	// tells us whether to restore a shutdown state afterward.
@@ -490,17 +557,6 @@ func cmdOn(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 	originallyShutdown := preserveBootState && device.State == "Shutdown"
-
-	p := Profile{ExceptCategories: map[string]bool{}, Keep: map[string]bool{}}
-	for _, id := range splitList(cmd.String("except")) {
-		if _, ok := categoryByID(id); !ok {
-			return fmt.Errorf("unknown category %q (see `simslim profiles`)", id)
-		}
-		p.ExceptCategories[id] = true
-	}
-	for _, l := range splitList(cmd.String("keep")) {
-		p.Keep[l] = true
-	}
 
 	fmt.Fprintf(os.Stderr, "Slimming %s: disabling %d background services. The simulator will reboot to apply the changes.\n", udid, len(p.desired()))
 	report := reporter(func(msg string) { fmt.Fprintln(os.Stderr, msg) })
@@ -653,7 +709,11 @@ COMMANDS
   list                 List available simulators and their slim status
   profiles [id]        Show the daemon categories a slim boot disables;
                        pass a category ID to list that category's daemons
+  profile [path]       Interactively build a --profile JSON file (writes to
+                       path or into a directory, or stdout when omitted)
   on <udid>            Slim a simulator (persist disables + reboot slim)
+      --profile path   Apply a committed JSON profile (see below); mutually
+                       exclusive with --except/--keep
       --except ids     Leave these categories enabled (comma-separated)
       --keep labels    Keep these individual daemons running (comma-separated)
       --preserve-boot-state
@@ -684,6 +744,12 @@ COMMANDS
 
 Disabling is persistent (stored in the simulator's launchd overrides) and fully
 reversible with ` + "`simslim off`" + `. Deadlock-prone daemons are never touched.
+
+A ` + "`--profile`" + ` file is JSON you commit alongside your project and apply per run
+(for example a ci.json and a dev.json). Its "except" and "keep" arrays match the
+flags of the same name:
+
+  { "name": "ci", "except": ["search", "store"], "keep": ["com.apple.apsd"] }
 
 Cleanup permanently removes existing cache, log, diagnostic, and temporary-file
 contents; Erase does not bring that history back, although new generated data

--- a/profile_file.go
+++ b/profile_file.go
@@ -1,0 +1,472 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// errWizardCancelled signals the user quit the builder; callers exit cleanly.
+var errWizardCancelled = errors.New("cancelled")
+
+// SlimProfile is the on-disk profile applied with `simslim on --profile <path>`.
+// Except and Keep mirror the `--except` and `--keep` flags.
+type SlimProfile struct {
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Except      []string `json:"except,omitempty"`
+	Keep        []string `json:"keep,omitempty"`
+}
+
+// loadSlimProfile reads a profile file and resolves it to a validated Profile.
+func loadSlimProfile(path string) (Profile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Profile{}, fmt.Errorf("read profile %s: %w", path, err)
+	}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	var sp SlimProfile
+	if err := dec.Decode(&sp); err != nil {
+		return Profile{}, fmt.Errorf("parse profile %s: %w", path, err)
+	}
+	return sp.resolve(path)
+}
+
+// resolve turns a parsed SlimProfile into the validated Profile it selects.
+func (sp SlimProfile) resolve(path string) (Profile, error) {
+	p := Profile{ExceptCategories: map[string]bool{}, Keep: map[string]bool{}}
+	for _, id := range sp.Except {
+		if id = strings.TrimSpace(id); id == "" {
+			continue
+		}
+		if _, ok := categoryByID(id); !ok {
+			return Profile{}, fmt.Errorf("profile %s: unknown category %q (see `simslim profiles`)", path, id)
+		}
+		p.ExceptCategories[id] = true
+	}
+	slimmable := slimmableSet()
+	for _, label := range sp.Keep {
+		if label = strings.TrimSpace(label); label == "" {
+			continue
+		}
+		if !slimmable[label] {
+			return Profile{}, fmt.Errorf("profile %s: %q is not a daemon any category disables (see `simslim profiles`)", path, label)
+		}
+		p.Keep[label] = true
+	}
+	return p, nil
+}
+
+// buildProfile selects the slim profile for an `on` invocation. A --profile
+// file is the single source of truth, so it cannot be combined with
+// --except/--keep.
+func buildProfile(profilePath, except, keep string) (Profile, error) {
+	if profilePath != "" {
+		if except != "" || keep != "" {
+			return Profile{}, fmt.Errorf("--profile cannot be combined with --except or --keep")
+		}
+		return loadSlimProfile(profilePath)
+	}
+	p := Profile{ExceptCategories: map[string]bool{}, Keep: map[string]bool{}}
+	for _, id := range splitList(except) {
+		if _, ok := categoryByID(id); !ok {
+			return Profile{}, fmt.Errorf("unknown category %q (see `simslim profiles`)", id)
+		}
+		p.ExceptCategories[id] = true
+	}
+	for _, l := range splitList(keep) {
+		p.Keep[l] = true
+	}
+	return p, nil
+}
+
+// marshalProfile renders a profile as indented JSON with a trailing newline.
+func marshalProfile(sp SlimProfile) ([]byte, error) {
+	data, err := json.MarshalIndent(sp, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return append(data, '\n'), nil
+}
+
+// profileFileName derives a JSON filename from a profile name, for when the
+// command targets a directory. Non-filename runs collapse to a hyphen; an empty
+// name falls back to profile.json.
+func profileFileName(name string) string {
+	var b strings.Builder
+	prevDash := false
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_', r == '.':
+			b.WriteRune(r)
+			prevDash = false
+		default:
+			if !prevDash {
+				b.WriteByte('-')
+				prevDash = true
+			}
+		}
+	}
+	slug := strings.Trim(b.String(), "-.")
+	if slug == "" {
+		return "profile.json"
+	}
+	if strings.HasSuffix(slug, ".json") {
+		return slug
+	}
+	return slug + ".json"
+}
+
+// stdinIsTerminal reports whether stdin is an interactive terminal.
+func stdinIsTerminal() bool {
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}
+
+// enterRawMode puts the terminal into raw, no-echo mode on the alternate screen
+// so the selector can read keystrokes and own the display. It returns the row
+// count and a restore func. It uses stty to avoid a terminal-handling dependency.
+func enterRawMode() (func(), int, error) {
+	stty := func(args ...string) *exec.Cmd {
+		c := exec.Command("stty", args...)
+		c.Stdin = os.Stdin
+		return c
+	}
+	saved, err := stty("-g").Output()
+	if err != nil {
+		return nil, 0, fmt.Errorf("read terminal state: %w", err)
+	}
+	rows := terminalRows(stty)
+	if err := stty("raw", "-echo").Run(); err != nil {
+		return nil, 0, fmt.Errorf("enter raw mode: %w", err)
+	}
+	fmt.Fprint(os.Stderr, "\x1b[?1049h\x1b[?25l") // alternate screen + hide cursor
+	return func() {
+		fmt.Fprint(os.Stderr, "\x1b[?25h\x1b[?1049l") // restore cursor + primary screen
+		_ = stty(strings.TrimSpace(string(saved))).Run()
+	}, rows, nil
+}
+
+// terminalRows reports the terminal height, defaulting to 24.
+func terminalRows(stty func(...string) *exec.Cmd) int {
+	out, err := stty("size").Output()
+	if err != nil {
+		return 24
+	}
+	fields := strings.Fields(string(out))
+	if len(fields) == 0 {
+		return 24
+	}
+	n, err := strconv.Atoi(fields[0])
+	if err != nil || n < 6 {
+		return 24
+	}
+	return n
+}
+
+// runProfileWizard interactively assembles a SlimProfile. Prompts go to out,
+// kept off stdout so the JSON stays redirectable. enterRaw switches the terminal
+// into per-keystroke mode and reports its height (a no-op in tests).
+func runProfileWizard(in io.Reader, out io.Writer, enterRaw func() (func(), int, error)) (SlimProfile, error) {
+	r := bufio.NewReader(in)
+	readLine := func(label string) string {
+		fmt.Fprint(out, label)
+		line, _ := r.ReadString('\n')
+		return strings.TrimSpace(line)
+	}
+
+	fmt.Fprintln(out, "Create a slim profile.")
+	fmt.Fprintln(out)
+	name := readLine("Name (optional): ")
+	description := readLine("Description (optional): ")
+
+	restore, rows, err := enterRaw()
+	if err != nil {
+		return SlimProfile{}, err
+	}
+	defer restore()
+
+	except, keep, cancelled := selectProfile(r, out, rows)
+	if cancelled {
+		return SlimProfile{}, errWizardCancelled
+	}
+
+	// Catalog order, and drop keeps inside an enabled feature (redundant).
+	var exceptIDs, keptLabels []string
+	for _, c := range Categories {
+		if except[c.ID] {
+			exceptIDs = append(exceptIDs, c.ID)
+			continue
+		}
+		for _, l := range c.Labels {
+			if keep[l] {
+				keptLabels = append(keptLabels, l)
+			}
+		}
+	}
+	return SlimProfile{Name: name, Description: description, Except: exceptIDs, Keep: keptLabels}, nil
+}
+
+// key is a normalized keystroke from readKey.
+type key int
+
+const (
+	keyOther key = iota
+	keyUp
+	keyDown
+	keyLeft
+	keyRight
+	keyEnter
+	keySpace
+	keyRune
+	keyCancel // Ctrl-C
+)
+
+// readKey reads one keystroke, decoding arrow sequences. The rune is set for keyRune.
+func readKey(r *bufio.Reader) (key, rune) {
+	b, err := r.ReadByte()
+	if err != nil {
+		return keyCancel, 0
+	}
+	switch b {
+	case '\r', '\n':
+		return keyEnter, 0
+	case ' ':
+		return keySpace, 0
+	case 3: // Ctrl-C
+		return keyCancel, 0
+	case 0x1b: // arrow keys arrive as ESC [ A/B/C/D
+		if b1, err := r.ReadByte(); err != nil || b1 != '[' {
+			return keyOther, 0
+		}
+		switch b2, _ := r.ReadByte(); b2 {
+		case 'A':
+			return keyUp, 0
+		case 'B':
+			return keyDown, 0
+		case 'C':
+			return keyRight, 0
+		case 'D':
+			return keyLeft, 0
+		}
+		return keyOther, 0
+	default:
+		return keyRune, rune(b)
+	}
+}
+
+// selectProfile runs the feature checklist: space keeps a whole feature, → drills
+// into its daemons. Returns the chosen Except and Keep sets. See the footer for keys.
+func selectProfile(r *bufio.Reader, out io.Writer, termRows int) (except, keep map[string]bool, cancelled bool) {
+	except = map[string]bool{}
+	keep = map[string]bool{}
+	header := []string{
+		"Features to keep enabled — everything unchecked is slimmed.",
+		"[x] whole feature kept · [~] some daemons kept",
+	}
+	footer := "↑/↓ move · space keep feature · → pick daemons · a all · n none · enter save · q cancel"
+	visible := viewportRows(termRows, len(header))
+	cursor, top := 0, 0
+	for {
+		rows := categoryRows(except, keep)
+		top = windowTop(top, cursor, visible, len(rows))
+		drawChecklist(out, header, rows, footer, cursor, top, visible)
+		k, ch := readKey(r)
+		switch {
+		case k == keyUp, k == keyRune && ch == 'k':
+			cursor = clampCursor(cursor-1, len(rows))
+		case k == keyDown, k == keyRune && ch == 'j':
+			cursor = clampCursor(cursor+1, len(rows))
+		case k == keyEnter:
+			return except, keep, false
+		case k == keyCancel, k == keyRune && (ch == 'q' || ch == 'Q'):
+			return nil, nil, true
+		case k == keySpace:
+			toggleMember(except, Categories[cursor].ID)
+		case k == keyRight, k == keyRune && ch == 'l':
+			if selectDaemons(r, out, Categories[cursor], keep, termRows) {
+				return nil, nil, true
+			}
+		case k == keyRune && (ch == 'a' || ch == 'A'):
+			for _, c := range Categories {
+				except[c.ID] = true
+			}
+		case k == keyRune && (ch == 'n' || ch == 'N'):
+			for id := range except {
+				delete(except, id)
+			}
+		}
+	}
+}
+
+// selectDaemons runs one feature's daemon checklist, mutating keep in place. ←/h
+// returns to the feature list; Ctrl-C aborts the whole wizard (via cancelled).
+func selectDaemons(r *bufio.Reader, out io.Writer, c Category, keep map[string]bool, termRows int) (cancelled bool) {
+	header := []string{
+		c.Name + " — keep individual daemons enabled.",
+		"Unchecked daemons in this feature are slimmed.",
+	}
+	footer := "↑/↓ move · space keep daemon · a all · n none · ← back · q cancel"
+	visible := viewportRows(termRows, len(header))
+	cursor, top := 0, 0
+	for {
+		rows := daemonRows(c, keep)
+		top = windowTop(top, cursor, visible, len(rows))
+		drawChecklist(out, header, rows, footer, cursor, top, visible)
+		k, ch := readKey(r)
+		switch {
+		case k == keyUp, k == keyRune && ch == 'k':
+			cursor = clampCursor(cursor-1, len(rows))
+		case k == keyDown, k == keyRune && ch == 'j':
+			cursor = clampCursor(cursor+1, len(rows))
+		case k == keyLeft, k == keyEnter, k == keyRune && (ch == 'h' || ch == 'q' || ch == 'Q'):
+			return false
+		case k == keyCancel:
+			return true
+		case k == keySpace:
+			toggleMember(keep, c.Labels[cursor])
+		case k == keyRune && (ch == 'a' || ch == 'A'):
+			for _, l := range c.Labels {
+				keep[l] = true
+			}
+		case k == keyRune && (ch == 'n' || ch == 'N'):
+			for _, l := range c.Labels {
+				delete(keep, l)
+			}
+		}
+	}
+}
+
+// categoryRows renders the feature list. Marker: [x] fully kept, [~] some daemons
+// kept, [ ] slimmed.
+func categoryRows(except, keep map[string]bool) []string {
+	rows := make([]string, len(Categories))
+	for i, c := range Categories {
+		box := "[ ]"
+		suffix := ""
+		switch {
+		case except[c.ID]:
+			box = "[x]"
+		default:
+			if n := categoryKeepCount(c, keep); n > 0 {
+				box = "[~]"
+				suffix = fmt.Sprintf("  (%d kept)", n)
+			}
+		}
+		rows[i] = fmt.Sprintf("%s %-14s %s%s", box, c.ID, c.Name, suffix)
+	}
+	return rows
+}
+
+// daemonRows renders one feature's daemons with a [x]/[ ] keep marker.
+func daemonRows(c Category, keep map[string]bool) []string {
+	rows := make([]string, len(c.Labels))
+	for i, l := range c.Labels {
+		box := "[ ]"
+		if keep[l] {
+			box = "[x]"
+		}
+		line := fmt.Sprintf("%s %s", box, l)
+		if desc := c.ServiceDescriptions[l]; desc != "" {
+			line = fmt.Sprintf("%s %-44s %s", box, l, desc)
+		}
+		rows[i] = truncate(line, 76)
+	}
+	return rows
+}
+
+func categoryKeepCount(c Category, keep map[string]bool) int {
+	n := 0
+	for _, l := range c.Labels {
+		if keep[l] {
+			n++
+		}
+	}
+	return n
+}
+
+// drawChecklist repaints the screen: header, a windowed slice of rows with a ❯
+// cursor, and a footer. It clears first, so each call fully replaces the frame.
+func drawChecklist(out io.Writer, header, rows []string, footer string, cursor, top, visible int) {
+	fmt.Fprint(out, "\x1b[H\x1b[J") // home + clear to end of screen
+	for _, h := range header {
+		fmt.Fprintf(out, "%s\r\n", h)
+	}
+	end := top + visible
+	if end > len(rows) {
+		end = len(rows)
+	}
+	for i := top; i < end; i++ {
+		pointer := "  "
+		if i == cursor {
+			pointer = "❯ "
+		}
+		fmt.Fprintf(out, "%s%s\r\n", pointer, rows[i])
+	}
+	more := ""
+	if top > 0 {
+		more += " ↑more"
+	}
+	if end < len(rows) {
+		more += " ↓more"
+	}
+	fmt.Fprintf(out, "\r\n%s%s", footer, more)
+}
+
+// viewportRows is how many list rows fit given the terminal height and header.
+func viewportRows(termRows, headerLines int) int {
+	v := termRows - headerLines - 2 // one blank line + one footer line
+	if v < 3 {
+		return 3
+	}
+	return v
+}
+
+// windowTop scrolls the viewport so the cursor stays visible.
+func windowTop(top, cursor, visible, total int) int {
+	if total <= visible {
+		return 0
+	}
+	if cursor < top {
+		top = cursor
+	}
+	if cursor >= top+visible {
+		top = cursor - visible + 1
+	}
+	if top > total-visible {
+		top = total - visible
+	}
+	if top < 0 {
+		top = 0
+	}
+	return top
+}
+
+func clampCursor(v, n int) int {
+	if v < 0 {
+		return 0
+	}
+	if v > n-1 {
+		return n - 1
+	}
+	return v
+}
+
+func toggleMember(set map[string]bool, key string) {
+	if set[key] {
+		delete(set, key)
+	} else {
+		set[key] = true
+	}
+}

--- a/profile_file_test.go
+++ b/profile_file_test.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// writeProfile writes contents to a temp file and returns its path.
+func writeProfile(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "profile.json")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	return path
+}
+
+func TestLoadSlimProfile(t *testing.T) {
+	path := writeProfile(t, `{
+		"name": "ci",
+		"description": "UI test runs",
+		"except": ["search", "store"],
+		"keep": ["com.apple.apsd"]
+	}`)
+	p, err := loadSlimProfile(path)
+	if err != nil {
+		t.Fatalf("loadSlimProfile() error = %v", err)
+	}
+	wantExcept := map[string]bool{"search": true, "store": true}
+	if !reflect.DeepEqual(p.ExceptCategories, wantExcept) {
+		t.Errorf("ExceptCategories = %v, want %v", p.ExceptCategories, wantExcept)
+	}
+	wantKeep := map[string]bool{"com.apple.apsd": true}
+	if !reflect.DeepEqual(p.Keep, wantKeep) {
+		t.Errorf("Keep = %v, want %v", p.Keep, wantKeep)
+	}
+}
+
+func TestLoadSlimProfileMinimal(t *testing.T) {
+	// name/description are optional and empty arrays yield an empty selection.
+	p, err := loadSlimProfile(writeProfile(t, `{}`))
+	if err != nil {
+		t.Fatalf("loadSlimProfile() error = %v", err)
+	}
+	if len(p.ExceptCategories) != 0 || len(p.Keep) != 0 {
+		t.Errorf("empty profile selected %v / %v, want empty", p.ExceptCategories, p.Keep)
+	}
+}
+
+func TestLoadSlimProfileRejects(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "unknown category", contents: `{"except": ["nope"]}`},
+		{name: "unknown keep label", contents: `{"keep": ["com.apple.does-not-exist"]}`},
+		{name: "unknown field", contents: `{"disable": ["search"]}`},
+		{name: "malformed json", contents: `{"except": [`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := loadSlimProfile(writeProfile(t, tt.contents)); err == nil {
+				t.Errorf("loadSlimProfile(%q) error = nil, want error", tt.contents)
+			}
+		})
+	}
+}
+
+func TestLoadSlimProfileMissingFile(t *testing.T) {
+	if _, err := loadSlimProfile(filepath.Join(t.TempDir(), "absent.json")); err == nil {
+		t.Error("loadSlimProfile(absent) error = nil, want error")
+	}
+}
+
+func TestBuildProfile(t *testing.T) {
+	t.Run("flags build the profile", func(t *testing.T) {
+		p, err := buildProfile("", "search", "com.apple.apsd")
+		if err != nil {
+			t.Fatalf("buildProfile() error = %v", err)
+		}
+		if !p.ExceptCategories["search"] || !p.Keep["com.apple.apsd"] {
+			t.Errorf("buildProfile flags = %v / %v", p.ExceptCategories, p.Keep)
+		}
+	})
+	t.Run("unknown category flag errors", func(t *testing.T) {
+		if _, err := buildProfile("", "nope", ""); err == nil {
+			t.Error("buildProfile(unknown category) error = nil, want error")
+		}
+	})
+	t.Run("profile file resolves", func(t *testing.T) {
+		path := writeProfile(t, `{"except": ["search"]}`)
+		p, err := buildProfile(path, "", "")
+		if err != nil {
+			t.Fatalf("buildProfile(file) error = %v", err)
+		}
+		if !p.ExceptCategories["search"] {
+			t.Errorf("buildProfile(file) except = %v", p.ExceptCategories)
+		}
+	})
+	t.Run("profile with except flag errors", func(t *testing.T) {
+		if _, err := buildProfile("some.json", "search", ""); err == nil {
+			t.Error("buildProfile(profile+except) error = nil, want error")
+		}
+	})
+	t.Run("profile with keep flag errors", func(t *testing.T) {
+		if _, err := buildProfile("some.json", "", "com.apple.apsd"); err == nil {
+			t.Error("buildProfile(profile+keep) error = nil, want error")
+		}
+	})
+}
+
+func TestProfileFileName(t *testing.T) {
+	tests := []struct {
+		name string
+		want string
+	}{
+		{name: "ci", want: "ci.json"},
+		{name: "UI Test Runs", want: "ui-test-runs.json"},
+		{name: "", want: "profile.json"},
+		{name: "  ", want: "profile.json"},
+		{name: "prod.json", want: "prod.json"},
+		{name: "a/b:c", want: "a-b-c.json"},
+		{name: "--weird--", want: "weird.json"},
+	}
+	for _, tt := range tests {
+		if got := profileFileName(tt.name); got != tt.want {
+			t.Errorf("profileFileName(%q) = %q, want %q", tt.name, got, tt.want)
+		}
+	}
+}
+
+// noRawMode is the enterRaw hook for tests: it skips terminal manipulation and
+// hands back a no-op restore plus a fixed height, so the wizard reads scripted
+// keystrokes from a plain reader.
+func noRawMode() (func(), int, error) { return func() {}, 24, nil }
+
+// Keystroke sequences the wizard consumes after the two (name, description)
+// lines. Categories are ordered widgets, siri, search, ... so one arrowDown
+// lands on siri, two on search.
+const (
+	arrowDown  = "\x1b[B"
+	arrowUp    = "\x1b[A"
+	arrowRight = "\x1b[C"
+	arrowLeft  = "\x1b[D"
+	space      = " "
+	enter      = "\r"
+)
+
+func TestRunProfileWizard(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantName   string
+		wantDesc   string
+		wantExcept []string
+		wantKeep   []string
+	}{
+		{
+			name:       "space keeps whole features siri and search",
+			input:      "ci\nUI test runs\n" + arrowDown + space + arrowDown + space + enter,
+			wantName:   "ci",
+			wantDesc:   "UI test runs",
+			wantExcept: []string{"siri", "search"}, // catalog order, not visit order
+		},
+		{
+			name:       "vim key navigates features",
+			input:      "\n\n" + "j" + space + enter,
+			wantExcept: []string{"siri"},
+		},
+		{
+			name:       "toggle feature twice clears",
+			input:      "\n\n" + space + space + enter,
+			wantExcept: nil,
+		},
+		{
+			name:       "all then none clears features",
+			input:      "\n\n" + "an" + enter,
+			wantExcept: nil,
+		},
+		{
+			name:       "enter with nothing checked",
+			input:      "\n\n" + enter,
+			wantExcept: nil,
+		},
+		{
+			name:       "unbound keys are ignored",
+			input:      "\n\n" + "zZ" + space + enter,
+			wantExcept: []string{"widgets"}, // z/Z do nothing; space keeps the cursor row
+		},
+		{
+			name:       "arrow up clamps at the top",
+			input:      "\n\n" + arrowUp + space + enter,
+			wantExcept: []string{"widgets"},
+		},
+		{
+			// Drill into siri (row 2), keep its first daemon, back out, save.
+			name:     "drill in keeps an individual daemon",
+			input:    "\n\n" + arrowDown + arrowRight + space + arrowLeft + enter,
+			wantKeep: []string{"com.apple.assistantd"},
+		},
+		{
+			// A kept daemon is dropped when its whole feature is also kept.
+			name:       "feature kept prunes its daemon keeps",
+			input:      "\n\n" + arrowDown + space + arrowRight + space + arrowLeft + enter,
+			wantExcept: []string{"siri"},
+			wantKeep:   nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp, err := runProfileWizard(strings.NewReader(tt.input), io.Discard, noRawMode)
+			if err != nil {
+				t.Fatalf("runProfileWizard() error = %v", err)
+			}
+			if sp.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", sp.Name, tt.wantName)
+			}
+			if sp.Description != tt.wantDesc {
+				t.Errorf("Description = %q, want %q", sp.Description, tt.wantDesc)
+			}
+			if !reflect.DeepEqual(sp.Except, tt.wantExcept) {
+				t.Errorf("Except = %v, want %v", sp.Except, tt.wantExcept)
+			}
+			if !reflect.DeepEqual(sp.Keep, tt.wantKeep) {
+				t.Errorf("Keep = %v, want %v", sp.Keep, tt.wantKeep)
+			}
+		})
+	}
+}
+
+// TestRunProfileWizardCancel confirms q reports cancellation.
+func TestRunProfileWizardCancel(t *testing.T) {
+	if _, err := runProfileWizard(strings.NewReader("\n\nq"), io.Discard, noRawMode); err != errWizardCancelled {
+		t.Errorf("runProfileWizard(q) error = %v, want errWizardCancelled", err)
+	}
+}
+
+// TestRunProfileWizardSelectAll confirms "a" checks every category so the
+// resulting Except list covers the full catalog in order.
+func TestRunProfileWizardSelectAll(t *testing.T) {
+	sp, err := runProfileWizard(strings.NewReader("\n\na"+enter), io.Discard, noRawMode)
+	if err != nil {
+		t.Fatalf("runProfileWizard() error = %v", err)
+	}
+	if len(sp.Except) != len(Categories) {
+		t.Fatalf("Except has %d entries, want %d", len(sp.Except), len(Categories))
+	}
+	for i, c := range Categories {
+		if sp.Except[i] != c.ID {
+			t.Errorf("Except[%d] = %q, want %q", i, sp.Except[i], c.ID)
+		}
+	}
+}
+
+// TestWizardOutputRoundTrips confirms a wizard result marshals to JSON that
+// loads back into an equivalent Profile.
+func TestWizardOutputRoundTrips(t *testing.T) {
+	sp, err := runProfileWizard(strings.NewReader("ci\n\n"+arrowDown+space+arrowDown+space+enter), io.Discard, noRawMode)
+	if err != nil {
+		t.Fatalf("runProfileWizard() error = %v", err)
+	}
+	data, err := marshalProfile(sp)
+	if err != nil {
+		t.Fatalf("marshalProfile() error = %v", err)
+	}
+	path := writeProfile(t, string(data))
+	p, err := loadSlimProfile(path)
+	if err != nil {
+		t.Fatalf("loadSlimProfile() error = %v", err)
+	}
+	want := map[string]bool{"siri": true, "search": true}
+	if !reflect.DeepEqual(p.ExceptCategories, want) {
+		t.Errorf("round-tripped ExceptCategories = %v, want %v", p.ExceptCategories, want)
+	}
+}


### PR DESCRIPTION
Implements #5.

## What

Named, committable slim configurations. A repo can carry e.g. a `ci.json` and a `dev.json` and apply whichever a run needs, instead of re-typing `--except`/`--keep` each time.

### Apply a profile

```sh
simslim on <udid> --profile ci.json
```

```json
{
  "name": "ci",
  "description": "UI test runs",
  "except": ["search", "store"],
  "keep": ["com.apple.apsd"]
}
```

- `except`/`keep` mirror the flags of the same name; `name`/`description` are for humans and ignored at apply time.
- Loading rejects **unknown JSON fields**, unknown category IDs, and non-slimmable labels, so a typo in a committed file fails loudly instead of silently slimming the wrong daemons.
- `--profile` is the single source of truth for its run and **cannot be combined** with `--except`/`--keep`.
- Resolved before touching the device, so a bad file fails before any boot.

### Build a profile interactively

```sh
simslim profile [path]
```

A two-level arrow-key TUI:

- **Feature list** — `space` keeps a whole feature enabled; `→` drills into that feature's daemons. Markers: `[x]` fully kept, `[~] (N kept)` some daemons kept, `[ ]` slimmed.
- **Daemon list** — `space` keeps an individual daemon; `←` returns.
- `↑`/`↓` (or `j`/`k`) move · `a`/`n` all/none · `enter` save · `q`/`Ctrl-C` cancel.

Writes to a file path, to `<name>.json` inside a directory, or to stdout when the path is omitted. An existing file is never overwritten. Redundant keeps (a daemon inside a fully-kept feature) are pruned from the output.

## Notes

- The TUI uses raw mode + the alternate screen buffer via `stty`, with viewport scrolling for long daemon lists — no new dependency (urfave/cli stays the only one), consistent with the tool already shelling out to `xcrun`/`pgrep`.
- GUI is unaffected: no shared JSON output structs changed.
- Tests cover loading/validation, `--profile` vs flag mutual-exclusion, filename derivation, and the full keystroke-driven wizard flow (drill-in and the pruning rule); `enterRaw` is injected as a no-op so no TTY is needed.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] Verified `--profile` apply, mutual-exclusion error, and non-TTY guard
- [x] Drove the two-level TUI through a real PTY: kept a whole feature and drilled into another for individual daemons, producing the expected JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)