### PR TITLE
feat: add doctor command to verify required features after slimming

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,11 @@ the GUI; its coverage and length are enforced in `profiles_test.go`.
 whose `except`/`keep` arrays mirror the flags of the same name, validates it
 against the allowlist, and resolves it to a `Profile`; it also holds the
 dependency-free `profile` command's wizard that assembles one interactively.
+`features.go` defines `Features`, a finer-grained catalog than `Categories`:
+each feature (push, storekit, universal-links, …) names just the daemons one
+testable capability needs. `doctor` reads a booted simulator's disabled labels
+and reports any required feature whose daemons are down, exiting non-zero — a CI
+preflight. `features_test.go` asserts every feature label is slimmable.
 `slim.go`'s `ensure()` boots the device, reads its currently
 disabled labels, computes a `delta` against the desired set, and applies the
 changes with `launchctl disable/enable` run inside the simulator via

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ simslim profiles <id>    # the daemons in one category
 simslim on <udid>        # slim a simulator and reboot it slim
 simslim off <udid>       # put it back to stock
 simslim status <udid>    # how slim a booted simulator is
+simslim doctor <udid> --requires push,storekit,universal-links
 simslim measure <udid>   # a booted simulator's memory footprint
 simslim size <udid>      # total allocated simulator size
 simslim disk-plan <udid> # measure reclaimable data; read-only
@@ -142,6 +143,28 @@ To build one interactively, run `simslim profile ci.json`: name it, then use the
 arrow keys and space to tick whole features to keep enabled, or press `→` to open
 a feature and keep individual daemons within it. Point it at a directory to save
 `<name>.json` there, or omit the path to print to stdout.
+
+### Checking a simulator with doctor
+
+Slimming a simulator turns features off on purpose, so a test suite that needs
+one of them wants a fast way to catch a mis-slimmed simulator before it runs.
+`doctor` checks a booted simulator against the features you name and exits
+non-zero if any of them are broken, which makes it a natural CI preflight:
+
+```sh
+simslim doctor <udid> --requires push,storekit,universal-links
+```
+
+```
+<udid>: 2/3 required features OK
+  ok     push
+  ok     universal-links
+  BROKEN storekit — com.apple.storekitd disabled
+```
+
+Feature IDs are finer-grained than the slimming categories: each maps to just
+the daemons that back one capability. Run `simslim doctor --list` to see them
+all. Both the check and the list support `--json`.
 
 ## How it works
 

--- a/app.go
+++ b/app.go
@@ -24,6 +24,11 @@ func newApp() *cli.Command {
 		{Name: "profiles", Flags: []cli.Flag{jsonFlag()}, Action: cmdProfiles},
 		{Name: "profile", Action: cmdNewProfile},
 		{Name: "status", Flags: []cli.Flag{jsonFlag(), &cli.BoolFlag{Name: "dropped", Usage: "list the disabled daemons grouped by category"}}, Action: cmdStatus},
+		{Name: "doctor", Flags: []cli.Flag{
+			jsonFlag(),
+			&cli.StringFlag{Name: "requires", Usage: "comma-separated feature IDs the simulator must support (see `simslim doctor --list`)"},
+			&cli.BoolFlag{Name: "list", Usage: "list every checkable feature and its backing daemons"},
+		}, Action: cmdDoctor},
 		{Name: "measure", Flags: []cli.Flag{jsonFlag()}, Action: cmdMeasure},
 		{Name: "size", Flags: []cli.Flag{jsonFlag()}, Action: cmdSize},
 		{Name: "disk-categories", Flags: []cli.Flag{jsonFlag()}, Action: cmdDiskCategories},

--- a/features.go
+++ b/features.go
@@ -1,0 +1,82 @@
+package main
+
+import "fmt"
+
+// Feature is a user-facing capability backed by specific launchd daemons.
+// Every label must also live in a Category (enforced in features_test.go), so a
+// feature only ever names daemons the tool could actually have turned off.
+type Feature struct {
+	ID     string   `json:"id"`
+	Name   string   `json:"name"`
+	Labels []string `json:"labels"`
+}
+
+// Features maps commonly required capabilities to the daemons they need running.
+var Features = []Feature{
+	{ID: "push", Name: "Push notifications", Labels: []string{"com.apple.apsd"}},
+	{ID: "storekit", Name: "StoreKit / in-app purchase", Labels: []string{"com.apple.storekitd"}},
+	{ID: "app-store", Name: "App Store", Labels: []string{"com.apple.appstored", "com.apple.itunesstored"}},
+	{ID: "universal-links", Name: "Universal links / associated domains", Labels: []string{"com.apple.swcd"}},
+	{ID: "spotlight", Name: "Spotlight & Settings search", Labels: []string{"com.apple.searchd", "com.apple.searchtoold"}},
+	{ID: "siri", Name: "Siri & speech", Labels: []string{"com.apple.assistantd", "com.apple.corespeechd"}},
+	{ID: "icloud", Name: "iCloud sync", Labels: []string{"com.apple.cloudd"}},
+	{ID: "keychain-sync", Name: "iCloud Keychain", Labels: []string{"com.apple.akd"}},
+	{ID: "contacts", Name: "Contacts", Labels: []string{"com.apple.contactsd"}},
+	{ID: "calendar", Name: "Calendar", Labels: []string{"com.apple.calaccessd"}},
+	{ID: "reminders", Name: "Reminders", Labels: []string{"com.apple.remindd"}},
+	{ID: "mail", Name: "Mail", Labels: []string{"com.apple.email.maild"}},
+	{ID: "photos", Name: "Photos library & analysis", Labels: []string{"com.apple.assetsd", "com.apple.photoanalysisd"}},
+	{ID: "health", Name: "HealthKit", Labels: []string{"com.apple.healthd"}},
+	{ID: "homekit", Name: "HomeKit", Labels: []string{"com.apple.homed"}},
+	{ID: "imessage", Name: "iMessage & FaceTime", Labels: []string{"com.apple.identityservicesd"}},
+	{ID: "widgets", Name: "Widgets & Live Activities", Labels: []string{"com.apple.chronod", "com.apple.liveactivitiesd"}},
+	{ID: "wallet", Name: "Wallet & passes", Labels: []string{"com.apple.passd"}},
+	{ID: "maps", Name: "Maps background services", Labels: []string{"com.apple.Maps.mapssyncd"}},
+	{ID: "weather", Name: "Weather", Labels: []string{"com.apple.weatherd"}},
+	{ID: "news", Name: "News", Labels: []string{"com.apple.newsd"}},
+	{ID: "game-center", Name: "Game Center", Labels: []string{"com.apple.gamed"}},
+	{ID: "find-my", Name: "Find My", Labels: []string{"com.apple.findmy.findmylocated"}},
+	{ID: "screen-time", Name: "Screen Time", Labels: []string{"com.apple.ScreenTimeAgent"}},
+}
+
+func featureByID(id string) (Feature, bool) {
+	for _, f := range Features {
+		if f.ID == id {
+			return f, true
+		}
+	}
+	return Feature{}, false
+}
+
+// resolveFeatures maps requested IDs to their Features, erroring on the first
+// unknown one so a typo in --requires fails loudly instead of passing silently.
+func resolveFeatures(ids []string) ([]Feature, error) {
+	out := make([]Feature, 0, len(ids))
+	for _, id := range ids {
+		f, ok := featureByID(id)
+		if !ok {
+			return nil, fmt.Errorf("unknown feature %q (see `simslim doctor --list`)", id)
+		}
+		out = append(out, f)
+	}
+	return out, nil
+}
+
+// diagnoseFeatures reports, for each feature, which of its daemons the device
+// currently has disabled. A feature is OK only when none of them are.
+func diagnoseFeatures(features []Feature, disabled map[string]bool) DoctorOutput {
+	statuses := make([]FeatureStatus, 0, len(features))
+	allOK := true
+	for _, f := range features {
+		var down []string
+		for _, l := range f.Labels {
+			if disabled[l] {
+				down = append(down, l)
+			}
+		}
+		ok := len(down) == 0
+		allOK = allOK && ok
+		statuses = append(statuses, FeatureStatus{ID: f.ID, Name: f.Name, OK: ok, Disabled: down})
+	}
+	return DoctorOutput{OK: allOK, Features: statuses}
+}

--- a/features_test.go
+++ b/features_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestFeatureLabelsAreSlimmable(t *testing.T) {
+	slimmable := slimmableSet()
+	for _, f := range Features {
+		if len(f.Labels) == 0 {
+			t.Errorf("feature %q has no labels", f.ID)
+		}
+		for _, l := range f.Labels {
+			if !slimmable[l] {
+				t.Errorf("feature %q names %q, which no category disables", f.ID, l)
+			}
+		}
+	}
+}
+
+func TestFeatureIDsAreUniqueAndNamed(t *testing.T) {
+	seen := map[string]bool{}
+	for _, f := range Features {
+		if f.ID == "" {
+			t.Error("a feature has an empty ID")
+		}
+		if f.Name == "" {
+			t.Errorf("feature %q has no name", f.ID)
+		}
+		if seen[f.ID] {
+			t.Errorf("duplicate feature ID %q", f.ID)
+		}
+		seen[f.ID] = true
+	}
+}
+
+func TestResolveFeatures(t *testing.T) {
+	got, err := resolveFeatures([]string{"push", "storekit"})
+	if err != nil {
+		t.Fatalf("resolveFeatures() error = %v", err)
+	}
+	if len(got) != 2 || got[0].ID != "push" || got[1].ID != "storekit" {
+		t.Errorf("resolveFeatures = %v, want [push storekit]", got)
+	}
+	if _, err := resolveFeatures([]string{"push", "nope"}); err == nil {
+		t.Error("resolveFeatures(unknown) error = nil, want error")
+	}
+}
+
+func TestDiagnoseFeatures(t *testing.T) {
+	features, err := resolveFeatures([]string{"push", "storekit", "universal-links"})
+	if err != nil {
+		t.Fatalf("resolveFeatures() error = %v", err)
+	}
+
+	t.Run("all healthy on a stock device", func(t *testing.T) {
+		report := diagnoseFeatures(features, map[string]bool{})
+		if !report.OK {
+			t.Errorf("OK = false, want true for %v", report.Features)
+		}
+	})
+
+	t.Run("a disabled daemon breaks its feature", func(t *testing.T) {
+		disabled := map[string]bool{"com.apple.storekitd": true}
+		report := diagnoseFeatures(features, disabled)
+		if report.OK {
+			t.Error("OK = true, want false when storekitd is disabled")
+		}
+		byID := map[string]FeatureStatus{}
+		for _, f := range report.Features {
+			byID[f.ID] = f
+		}
+		if byID["storekit"].OK {
+			t.Error("storekit reported OK despite storekitd disabled")
+		}
+		if !reflect.DeepEqual(byID["storekit"].Disabled, []string{"com.apple.storekitd"}) {
+			t.Errorf("storekit.Disabled = %v, want [com.apple.storekitd]", byID["storekit"].Disabled)
+		}
+		if !byID["push"].OK || !byID["universal-links"].OK {
+			t.Error("unrelated features should stay OK")
+		}
+	})
+
+	t.Run("any disabled backing daemon breaks a multi-daemon feature", func(t *testing.T) {
+		spotlight, _ := resolveFeatures([]string{"spotlight"})
+		report := diagnoseFeatures(spotlight, map[string]bool{"com.apple.searchtoold": true})
+		if report.OK {
+			t.Error("spotlight reported OK with searchtoold disabled")
+		}
+	})
+}

--- a/main.go
+++ b/main.go
@@ -259,6 +259,66 @@ func cmdStatus(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
+func cmdDoctor(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	if cmd.Bool("list") {
+		if cmd.Args().Len() != 0 {
+			return fmt.Errorf("doctor --list takes no arguments")
+		}
+		if jsonOutput {
+			return writeJSON(Features)
+		}
+		for _, f := range Features {
+			fmt.Printf("%-16s %-38s %s\n", f.ID, f.Name, strings.Join(f.Labels, ", "))
+		}
+		return nil
+	}
+
+	udid, err := oneUDID(cmd.Args().Slice())
+	if err != nil {
+		return err
+	}
+	features, err := resolveFeatures(splitList(cmd.String("requires")))
+	if err != nil {
+		return err
+	}
+	if len(features) == 0 {
+		return fmt.Errorf("doctor needs at least one feature via --requires (see `simslim doctor --list`)")
+	}
+
+	_, disabled, err := status(ctx, udid)
+	if err != nil {
+		return err
+	}
+	report := diagnoseFeatures(features, disabled)
+	report.UDID = udid
+
+	if jsonOutput {
+		if err := writeJSON(report); err != nil {
+			return err
+		}
+	} else {
+		broken := 0
+		for _, f := range report.Features {
+			if !f.OK {
+				broken++
+			}
+		}
+		fmt.Printf("%s: %d/%d required features OK\n", udid, len(report.Features)-broken, len(report.Features))
+		for _, f := range report.Features {
+			if f.OK {
+				fmt.Printf("  ok    %s\n", f.ID)
+			} else {
+				fmt.Printf("  BROKEN %s — %s disabled\n", f.ID, strings.Join(f.Disabled, ", "))
+			}
+		}
+	}
+	if !report.OK {
+		os.Exit(1)
+	}
+	return nil
+}
+
 func cmdMeasure(ctx context.Context, cmd *cli.Command) error {
 	jsonOutput := cmd.Bool("json")
 	udid, err := oneUDID(cmd.Args().Slice())
@@ -723,6 +783,10 @@ COMMANDS
                        Return an initially shutdown simulator to shutdown
   status <udid>        Report how slim a booted simulator is
       --dropped        Also list the disabled daemons grouped by category
+  doctor <udid>        Check required features against a booted simulator;
+                       exits non-zero if slimming has broken any of them
+      --requires ids   Comma-separated feature IDs to verify
+      --list           List every checkable feature and its daemons
   measure <udid>       Report a booted simulator's memory footprint
   size <udid>          Report a simulator's allocated disk footprint
   disk-categories      Show cleanup and protected system-asset categories

--- a/output.go
+++ b/output.go
@@ -41,6 +41,22 @@ type SimulatorMutationOutput struct {
 	SourceUDID string `json:"sourceUdid,omitempty"`
 }
 
+// DoctorOutput reports whether each required feature survives the device's
+// current slimming. OK is false when any required feature has a disabled daemon.
+type DoctorOutput struct {
+	UDID     string          `json:"udid,omitempty"`
+	OK       bool            `json:"ok"`
+	Features []FeatureStatus `json:"features"`
+}
+
+// FeatureStatus is one feature's verdict: the daemons it needs that are down.
+type FeatureStatus struct {
+	ID       string   `json:"id"`
+	Name     string   `json:"name"`
+	OK       bool     `json:"ok"`
+	Disabled []string `json:"disabled,omitempty"`
+}
+
 type DiskMeasurement struct {
 	Bytes int64 `json:"bytes"`
 }


### PR DESCRIPTION
Implements #4.

## What

`simslim doctor <udid> --requires push,storekit,universal-links` checks a **booted** simulator against a list of required feature IDs and **exits non-zero** if slimming has disabled any of their backing daemons. It's meant as a CI preflight: abort before a suite runs against a simulator that's been slimmed too aggressively for what that suite needs.

```
$ simslim doctor <udid> --requires push,storekit,universal-links,spotlight
<udid>: 0/4 required features OK
  BROKEN push — com.apple.apsd disabled
  BROKEN storekit — com.apple.storekitd disabled
  BROKEN universal-links — com.apple.swcd disabled
  BROKEN spotlight — com.apple.searchd, com.apple.searchtoold disabled
exit=1
```

A stock simulator reports `N/N required features OK` and exits `0`.

## How

- **`features.go`** — a new `Features` catalog, intentionally finer-grained than the GUI's `Categories`: each feature (push, storekit, universal-links, spotlight, siri, icloud, contacts, … 24 total) maps to just the daemons that back that one capability. `resolveFeatures` errors loudly on an unknown ID (typo in `--requires` fails, doesn't pass silently); `diagnoseFeatures` is pure and reports exactly which daemons are down per feature.
- **`main.go` / `app.go`** — `doctor` reads the device's disabled labels via the existing `status()`, supports `--json`, and `--list` to enumerate every checkable feature and its daemons.
- **`features_test.go`** — asserts every feature label is in `slimmableSet()`, so the catalog can't drift out of sync with `Categories`; also covers `resolveFeatures` and single/multi-daemon breakage in `diagnoseFeatures`.

## Notes

- No new dependencies.
- GUI unaffected: adds new JSON structs (`DoctorOutput`, `FeatureStatus`) but changes none of the existing contract the SwiftUI app decodes.

## Test plan

- `make check` green (go test, vet, swift-format lint, script/plist lint).
- Verified live against booted sims: fully-slimmed sim → all required features BROKEN, exit 1; stock sim → all OK, exit 0; `--json` and `--list` output confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)