### PR TITLE
Make boot timeout configurable for slow CI runners

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,8 +115,11 @@ The app is a thin front end that shells out to that bundled binary.
   `Action`. `main.go` still owns `version`/`help`/no-args and the macOS-only guard
   before handing off to the tree, and routes every command error through `fatal()`
   for the stable `simslim: <msg>` (exit 1); unknown commands exit 2 with usage.
-- Two timeouts live in `simctl.go`: `ShutdownTimeout` (30s) and `BootTimeout` (6min,
-  because a first slim reconfigure boots twice).
+- Two timeouts live in `simctl.go`: `ShutdownTimeout` (30s, a const) and `BootTimeout`
+  (10min, because a first slim reconfigure boots twice). `BootTimeout` is a package var,
+  not a const, so the CLI's global `--boot-timeout` flag (env `SIMSLIM_BOOT_TIMEOUT`,
+  wired in `app.go` like `--set`) can raise it for slow CI runners where the per-daemon
+  `launchctl` transitions would otherwise blow the deadline mid-reconfigure.
 - Progress for multi-minute operations goes to **stderr** via the `Reporter` callback;
   machine-readable JSON goes to **stdout**. Under `--json`, suppress the stderr
   chatter so consumers reading a combined stream still get clean JSON.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,20 @@ simslim delete <udid>    # permanently delete a simulator
 Read-only and simulator-management commands accept `--json` for integrations
 and the macOS app.
 
+### Slow CI runners
+
+`simslim on` boots the simulator, disables ~170 daemons one `launchctl` call at a
+time, then reboots — all under a single 10-minute deadline. Shared CI runners (like
+GitHub-hosted macOS runners) are slower and less predictable, and can blow that
+deadline mid-reconfigure with `context deadline exceeded` errors. Raise it with the
+global `--boot-timeout` flag or the `SIMSLIM_BOOT_TIMEOUT` environment variable:
+
+```sh
+simslim on <udid> --boot-timeout 15m
+# or, for the whole job:
+export SIMSLIM_BOOT_TIMEOUT=15m
+```
+
 ## Disk cleanup
 
 Disk cleanup is permanent and separate from service slimming. `disk-plan` is

--- a/cmd/simslim/app.go
+++ b/cmd/simslim/app.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	cli "github.com/urfave/cli/v3"
 
@@ -85,6 +86,19 @@ func newApp() *cli.Command {
 					for _, set := range sets {
 						simslim.RegisterDeviceSet(set)
 					}
+					return nil
+				},
+			},
+			&cli.DurationFlag{
+				Name:    "boot-timeout",
+				Usage:   "max time for a simulator to boot and reconfigure (e.g. 10m, 15m); raise it for slow CI runners",
+				Sources: cli.EnvVars("SIMSLIM_BOOT_TIMEOUT"),
+				Value:   simslim.BootTimeout,
+				Action: func(_ context.Context, _ *cli.Command, d time.Duration) error {
+					if d <= 0 {
+						return fmt.Errorf("--boot-timeout must be a positive duration (such as `15m`)")
+					}
+					simslim.BootTimeout = d
 					return nil
 				},
 			},

--- a/cmd/simslim/app_test.go
+++ b/cmd/simslim/app_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/mobai-app/simslim"
 )
@@ -57,6 +58,48 @@ func TestAppRegistersDeviceSets(t *testing.T) {
 			gotExtra := simslim.ExtraDeviceSetTokens()
 			if !reflect.DeepEqual(gotExtra, tt.wantExtra) {
 				t.Errorf("registered extra sets = %v, want %v", gotExtra, tt.wantExtra)
+			}
+		})
+	}
+}
+
+// TestAppBootTimeoutFlag verifies --boot-timeout and its SIMSLIM_BOOT_TIMEOUT env
+// source override simslim.BootTimeout, and that a non-positive duration is rejected.
+func TestAppBootTimeoutFlag(t *testing.T) {
+	const def = 10 * time.Minute
+	tests := []struct {
+		name      string
+		args      []string
+		env       string // value for SIMSLIM_BOOT_TIMEOUT, "" to leave unset
+		want      time.Duration
+		wantError bool
+	}{
+		{name: "absent keeps default", args: []string{"profiles"}, want: def},
+		{name: "before command", args: []string{"--boot-timeout", "15m", "profiles"}, want: 15 * time.Minute},
+		{name: "after command", args: []string{"profiles", "--boot-timeout", "15m"}, want: 15 * time.Minute},
+		{name: "equals form", args: []string{"profiles", "--boot-timeout=20m"}, want: 20 * time.Minute},
+		{name: "from env", args: []string{"profiles"}, env: "12m", want: 12 * time.Minute},
+		{name: "flag overrides env", args: []string{"profiles", "--boot-timeout", "9m"}, env: "12m", want: 9 * time.Minute},
+		{name: "zero rejected", args: []string{"profiles", "--boot-timeout", "0"}, want: def, wantError: true},
+		{name: "negative rejected", args: []string{"profiles", "--boot-timeout", "-1m"}, want: def, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			simslim.ResetDeviceSets()
+			defer simslim.ResetDeviceSets()
+			orig := simslim.BootTimeout
+			simslim.BootTimeout = def
+			defer func() { simslim.BootTimeout = orig }()
+			if tt.env != "" {
+				t.Setenv("SIMSLIM_BOOT_TIMEOUT", tt.env)
+			}
+			err := runApp(t, tt.args...)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("Run(%v) error = %v, wantError %v", tt.args, err, tt.wantError)
+			}
+			if simslim.BootTimeout != tt.want {
+				t.Errorf("BootTimeout = %v, want %v", simslim.BootTimeout, tt.want)
 			}
 		})
 	}

--- a/cmd/simslim/main.go
+++ b/cmd/simslim/main.go
@@ -750,6 +750,9 @@ GLOBAL OPTIONS
   --set <name|path>    Also scan these device sets (comma-separated). The default
                        and Xcode ` + "`testing`" + ` (parallel-testing) sets are always
                        scanned; use this to add a set at a custom path.
+  --boot-timeout dur   Max time to boot and reconfigure a simulator (default 10m;
+                       e.g. ` + "`15m`" + `). Raise it for slow CI runners. Also settable
+                       via the SIMSLIM_BOOT_TIMEOUT environment variable.
 
 COMMANDS
   list                 List available simulators and their slim status

--- a/simctl.go
+++ b/simctl.go
@@ -11,11 +11,11 @@ import (
 	"unicode/utf8"
 )
 
-// Default timeouts for the simulator operations this package drives.
-const (
-	ShutdownTimeout = 30 * time.Second
-	BootTimeout     = 6 * time.Minute // a first slim reconfigure boots twice
-)
+const ShutdownTimeout = 30 * time.Second
+
+// BootTimeout bounds a full boot-and-reconfigure (boots twice on a first slim); a
+// var, not a const, so `--boot-timeout` / SIMSLIM_BOOT_TIMEOUT can raise it for CI.
+var BootTimeout = 10 * time.Minute
 
 // Device is a simulator as reported by `simctl list`.
 type Device struct {


### PR DESCRIPTION
## Problem

Fixes #13. `simslim on` boots the simulator, disables ~170 daemons one `launchctl` call at a time, then reboots — all under a single `BootTimeout` deadline. Despite the issue title, the reported failures aren't the *boot* timing out: they're `context deadline exceeded` (and one `signal: killed`) on the individual `launchctl disable` transitions. On slow, shared CI runners (e.g. GitHub-hosted macOS) those transitions alone exhaust the 6-minute budget, so the deadline fires mid-reconfigure and every remaining transition fails.

## Change

- `BootTimeout` is now a package `var` instead of a `const`, with the default raised from 6m to **10m**.
- New global `--boot-timeout` flag (persistent across subcommands, like `--set`) with a `SIMSLIM_BOOT_TIMEOUT` env source. Accepts Go durations (`15m`), rejects non-positive values.
- Setting it just assigns `simslim.BootTimeout`, so every existing `context.WithTimeout(ctx, simslim.BootTimeout)` call site picks it up with no other changes.
- Docs: README "Slow CI runners" section, `usage()`, and CLAUDE.md.

```sh
simslim on <udid> --boot-timeout 15m
# or, for a whole CI job:
export SIMSLIM_BOOT_TIMEOUT=15m
```

## Tests

`TestAppBootTimeoutFlag` covers before/after subcommand, `=` form, env source, flag-overrides-env, absent-keeps-default, and rejection of zero/negative durations. `go test ./...`, `go vet`, and `gofmt` all clean.