### PR TITLE
docs: fix missing relative pronoun 'that' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ simslim on <udid> --profile ci.json
 
 `except` and `keep` mirror the flags of the same name; `name` and `description`
 are for whoever reads the file. Unknown fields, unknown category IDs, and labels
-no category disables are rejected, so a typo fails loudly. `--profile` is the
+that no category disables are rejected, so a typo fails loudly. `--profile` is the
 single source of truth for its run and cannot be combined with `--except` or
 `--keep`.
 


### PR DESCRIPTION
Fixes a grammar issue on line 152-153 of README.md: the phrase "labels no category disables" is missing the relative pronoun "that", creating a garden-path sentence that is difficult to parse. Adding "that" makes it clear: "labels that no category disables are rejected".