### PR TITLE
retry failed launchctl transitions with a per-spawn timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,17 @@ simslim on <udid> --boot-timeout 15m
 export SIMSLIM_BOOT_TIMEOUT=15m
 ```
 
+Each individual `launchctl` transition is also bounded by its own 2-minute
+timeout, and the first transitions after a cold boot can exceed that on slow
+hosts (failed ones are retried automatically). Raise it with the global
+`--spawn-timeout` flag or the `SIMSLIM_SPAWN_TIMEOUT` environment variable:
+
+```sh
+simslim on <udid> --spawn-timeout 5m
+# or, for the whole job:
+export SIMSLIM_SPAWN_TIMEOUT=5m
+```
+
 ## Disk cleanup
 
 Disk cleanup is permanent and separate from service slimming. `disk-plan` is

--- a/cmd/simslim/app.go
+++ b/cmd/simslim/app.go
@@ -103,6 +103,19 @@ func newApp() *cli.Command {
 					return nil
 				},
 			},
+			&cli.DurationFlag{
+				Name:    "spawn-timeout",
+				Usage:   "max time for a single launchctl transition inside the simulator (e.g. 2m, 5m); raise it for slow hosts",
+				Sources: cli.EnvVars("SIMSLIM_SPAWN_TIMEOUT"),
+				Value:   simslim.SpawnTimeout,
+				Action: func(_ context.Context, _ *cli.Command, d time.Duration) error {
+					if d <= 0 {
+						return fmt.Errorf("--spawn-timeout must be a positive duration (such as `2m`)")
+					}
+					simslim.SpawnTimeout = d
+					return nil
+				},
+			},
 		},
 		Action: func(_ context.Context, cmd *cli.Command) error {
 			if args := cmd.Args().Slice(); len(args) > 0 {

--- a/cmd/simslim/app_test.go
+++ b/cmd/simslim/app_test.go
@@ -133,3 +133,45 @@ func TestAppFlagParsing(t *testing.T) {
 		})
 	}
 }
+
+// TestAppSpawnTimeoutFlag verifies --spawn-timeout and its SIMSLIM_SPAWN_TIMEOUT env
+// source override simslim.SpawnTimeout, and that a non-positive duration is rejected.
+func TestAppSpawnTimeoutFlag(t *testing.T) {
+	const def = 2 * time.Minute
+	tests := []struct {
+		name      string
+		args      []string
+		env       string // value for SIMSLIM_SPAWN_TIMEOUT, "" to leave unset
+		want      time.Duration
+		wantError bool
+	}{
+		{name: "absent keeps default", args: []string{"profiles"}, want: def},
+		{name: "before command", args: []string{"--spawn-timeout", "5m", "profiles"}, want: 5 * time.Minute},
+		{name: "after command", args: []string{"profiles", "--spawn-timeout", "5m"}, want: 5 * time.Minute},
+		{name: "equals form", args: []string{"profiles", "--spawn-timeout=4m"}, want: 4 * time.Minute},
+		{name: "from env", args: []string{"profiles"}, env: "3m", want: 3 * time.Minute},
+		{name: "flag overrides env", args: []string{"profiles", "--spawn-timeout", "90s"}, env: "3m", want: 90 * time.Second},
+		{name: "zero rejected", args: []string{"profiles", "--spawn-timeout", "0"}, want: def, wantError: true},
+		{name: "negative rejected", args: []string{"profiles", "--spawn-timeout", "-1m"}, want: def, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			simslim.ResetDeviceSets()
+			defer simslim.ResetDeviceSets()
+			orig := simslim.SpawnTimeout
+			simslim.SpawnTimeout = def
+			defer func() { simslim.SpawnTimeout = orig }()
+			if tt.env != "" {
+				t.Setenv("SIMSLIM_SPAWN_TIMEOUT", tt.env)
+			}
+			err := runApp(t, tt.args...)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("Run(%v) error = %v, wantError %v", tt.args, err, tt.wantError)
+			}
+			if simslim.SpawnTimeout != tt.want {
+				t.Errorf("SpawnTimeout = %v, want %v", simslim.SpawnTimeout, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/simslim/main.go
+++ b/cmd/simslim/main.go
@@ -832,6 +832,11 @@ GLOBAL OPTIONS
   --boot-timeout dur   Max time to boot and reconfigure a simulator (default 10m;
                        e.g. ` + "`15m`" + `). Raise it for slow CI runners. Also settable
                        via the SIMSLIM_BOOT_TIMEOUT environment variable.
+  --spawn-timeout dur  Max time for a single launchctl transition inside the
+                       simulator (default 2m). Raise it for hosts where a busy
+                       first boot makes individual spawns very slow. Also
+                       settable via the SIMSLIM_SPAWN_TIMEOUT environment
+                       variable.
 
 COMMANDS
   list                 List available simulators and their slim status

--- a/simctl.go
+++ b/simctl.go
@@ -364,44 +364,81 @@ func parseDisabled(output string) map[string]bool {
 	return set
 }
 
+// SpawnTimeout bounds a single `simctl spawn launchctl` transition. Right
+// after a first boot — especially on older Intel hosts — the simulator is
+// saturated by data migration and Spotlight indexing, and an individual spawn
+// can stall for many minutes. A per-spawn bound turns one stuck spawn into a
+// retryable failure instead of letting it consume the whole reconfigure
+// budget; the label is retried on a later pass once the device has settled.
+// A var, not a const, so SIMSLIM_SPAWN_TIMEOUT can raise it for slow hosts.
+var SpawnTimeout = 2 * time.Minute
+
+// applyPasses is how many times applyDelta walks the remaining labels.
+// Disables are persistent, so each pass only retries what previous passes
+// failed; on a freshly booted device the later passes run against a warm
+// launchd and typically finish in seconds per label.
+const applyPasses = 3
+
 // applyDelta disables then enables the given labels. launchctl must be the
 // direct target of `simctl spawn`: a shell wrapper (`simctl spawn udid sh -c
 // '...'`) does not propagate DYLD_ROOT_PATH, so the nested launchctl aborts with
 // "DYLD_ROOT_PATH not set for simulator program". launchctl exits 0 even when it
 // prints the benign "switch to user/foreground" note, so a non-zero exit is a
-// real failure; failures are aggregated rather than aborting the whole profile.
+// real failure; failures are collected and retried on later passes rather than
+// aborting the whole profile.
 func applyDelta(ctx context.Context, set, udid string, toDisable, toEnable []string, report Reporter) error {
-	total := len(toDisable) + len(toEnable)
+	type transition struct{ action, label string }
+	pending := make([]transition, 0, len(toDisable)+len(toEnable))
+	for _, l := range toDisable {
+		pending = append(pending, transition{"disable", l})
+	}
+	for _, l := range toEnable {
+		pending = append(pending, transition{"enable", l})
+	}
+	total := len(pending)
 	run := func(action, label string) error {
-		out, err := exec.CommandContext(ctx, "xcrun", simctlArgs(set, "spawn", udid,
+		spawnCtx, cancel := context.WithTimeout(ctx, SpawnTimeout)
+		defer cancel()
+		out, err := exec.CommandContext(spawnCtx, "xcrun", simctlArgs(set, "spawn", udid,
 			"launchctl", action, "system/"+label)...).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf("%s %s: %w: %s", action, label, err, strings.TrimSpace(string(out)))
 		}
 		return nil
 	}
-	var failures []string
 	done := 0
-	step := func(action, label string) {
-		if err := run(action, label); err != nil {
-			failures = append(failures, err.Error())
+	var failures []string
+	for pass := 1; pass <= applyPasses && len(pending) > 0; pass++ {
+		if pass > 1 {
+			report.report(fmt.Sprintf("  retrying %d failed services (pass %d/%d)...",
+				len(pending), pass, applyPasses))
 		}
-		done++
-		// One process per label is slow (~30s for a full profile); a periodic
-		// count reassures the caller that it has not hung.
-		if done == total || done%20 == 0 {
-			report.report(fmt.Sprintf("  %d/%d services updated", done, total))
+		var failed []transition
+		failures = failures[:0]
+		for _, t := range pending {
+			if err := run(t.action, t.label); err != nil {
+				if ctx.Err() != nil {
+					// The overall reconfigure budget is exhausted; stop
+					// instead of burning through the rest of the labels.
+					return fmt.Errorf("%d/%d launchctl transitions incomplete: %w",
+						total-done, total, ctx.Err())
+				}
+				failed = append(failed, t)
+				failures = append(failures, err.Error())
+				continue
+			}
+			done++
+			// One process per label is slow (~30s for a full profile); a periodic
+			// count reassures the caller that it has not hung.
+			if done == total || done%20 == 0 {
+				report.report(fmt.Sprintf("  %d/%d services updated", done, total))
+			}
 		}
+		pending = failed
 	}
-	for _, l := range toDisable {
-		step("disable", l)
-	}
-	for _, l := range toEnable {
-		step("enable", l)
-	}
-	if len(failures) > 0 {
-		return fmt.Errorf("%d/%d launchctl transitions failed: %s",
-			len(failures), total, strings.Join(failures, "; "))
+	if len(pending) > 0 {
+		return fmt.Errorf("%d/%d launchctl transitions failed after %d passes: %s",
+			len(pending), total, applyPasses, strings.Join(failures, "; "))
 	}
 	return nil
 }


### PR DESCRIPTION
On slower hosts (e.g. Intel Macs) individual launchctl spawns inside a freshly booted simulator can take minutes, so a single slow transition used to consume the whole command deadline and abort the run partway through, leaving the simulator half-configured.

applyDelta now bounds each transition with its own timeout (default 2m, tunable via --spawn-timeout / SIMSLIM_SPAWN_TIMEOUT) and collects the labels that failed, retrying only those for up to three passes before reporting the remaining failures. Overrides are persistent and the delta is recomputed per run, so retried passes are cheap.

Verified on an Intel 2017 MacBook Pro (macOS 15.7.8, Xcode 26.6, iOS 26.5): a full 170-service disable on a fresh iPhone 17 simulator completed in a single run (~5.3 min) where the previous behavior could abort on the first slow spawn.