### PR TITLE
fix: keep AMS daemons enabled with --except store so in-app purchases work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,11 @@ a breaking change for importers as well as for the CLI.
 
 **The slimming model (the core idea).** `profiles.go` defines `Categories`, an
 allowlist of launchd daemon labels grouped by user-facing feature (siri, search,
-icloud, …). `SlimmableSet()` is the union of every label in `Categories`.
+icloud, …). Categories may overlap — a label lives in every category whose
+feature needs it (e.g. the AMS payment-sheet daemons are in both `store` and
+`icloud`), and `Profile.Desired()` keeps a label enabled when **any** excepted
+category lists it. `SlimmableSet()` is the deduplicated union of every label in
+`Categories`.
 `managedSet()` adds each category's `AlwaysEnabled` compatibility services,
 which simslim may only repair back to enabled; these are **the only labels the
 tool may ever disable or enable.** Anything outside those sets is never touched.

--- a/features.go
+++ b/features.go
@@ -14,7 +14,15 @@ type Feature struct {
 // Features maps commonly required capabilities to the daemons they need running.
 var Features = []Feature{
 	{ID: "push", Name: "Push notifications", Labels: []string{"com.apple.apsd"}},
-	{ID: "storekit", Name: "StoreKit / in-app purchase", Labels: []string{"com.apple.storekitd"}},
+	// In-app purchase needs the store daemons plus AMS, which presents the
+	// payment sheet — products load without AMS but purchases fail.
+	{ID: "storekit", Name: "StoreKit / in-app purchase", Labels: []string{
+		"com.apple.storekitd",
+		"com.apple.itunesstored",
+		"com.apple.amsaccountsd",
+		"com.apple.amsengagementd",
+		"com.apple.amsondevicestoraged",
+	}},
 	{ID: "app-store", Name: "App Store", Labels: []string{"com.apple.appstored", "com.apple.itunesstored"}},
 	{ID: "universal-links", Name: "Universal links / associated domains", Labels: []string{"com.apple.swcd"}},
 	{ID: "spotlight", Name: "Spotlight & Settings search", Labels: []string{"com.apple.searchd", "com.apple.searchtoold"}},

--- a/gui/AppModel.swift
+++ b/gui/AppModel.swift
@@ -46,11 +46,17 @@ final class AppModel: ObservableObject {
     isRefreshing || batchProgress != nil || !activeOperations.isEmpty
   }
 
-  var disabledDaemonCount: Int {
-    categories.reduce(0) { count, category in
-      guard !categoryIsKept(category) else { return count }
-      return count + category.labels.filter { !keptServiceLabels.contains($0) }.count
+  /// Labels kept enabled by a kept category or an individual keep. Categories
+  /// may share labels, so a shared label is kept when any of its categories is.
+  var effectiveKeptLabels: Set<String> {
+    categories.reduce(into: keptServiceLabels) { kept, category in
+      if categoryIsKept(category) { kept.formUnion(category.labels) }
     }
+  }
+
+  var disabledDaemonCount: Int {
+    let allLabels = categories.reduce(into: Set<String>()) { $0.formUnion($1.labels) }
+    return allLabels.subtracting(effectiveKeptLabels).count
   }
 
   var bootedCount: Int { devices.filter(\.isBooted).count }
@@ -196,8 +202,8 @@ final class AppModel: ObservableObject {
       || category.labels.allSatisfy { keptServiceLabels.contains($0) }
   }
 
-  func serviceIsKept(_ label: String, in category: SlimCategory) -> Bool {
-    categoryIsKept(category) || keptServiceLabels.contains(label)
+  func serviceIsKept(_ label: String) -> Bool {
+    effectiveKeptLabels.contains(label)
   }
 
   func setService(_ label: String, in category: SlimCategory, keptEnabled: Bool) {

--- a/gui/ContentView.swift
+++ b/gui/ContentView.swift
@@ -982,7 +982,7 @@ private struct ServiceToggle: View {
 
   private var isKeptEnabled: Binding<Bool> {
     Binding(
-      get: { model.serviceIsKept(label, in: category) },
+      get: { model.serviceIsKept(label) },
       set: { model.setService(label, in: category, keptEnabled: $0) }
     )
   }

--- a/profiles.go
+++ b/profiles.go
@@ -23,6 +23,9 @@ type AlwaysEnabledService struct {
 }
 
 // Categories is the complete allowlist of daemons a profile may disable.
+// Categories may overlap: a label lives in every category whose feature needs
+// it, and an excepted category keeps all its labels enabled even when a
+// slimmed category also lists them.
 // ApproxMemoryMB values are rounded median increases in phys_footprint when
 // only that category is kept on versus a fully slim iOS 26.5 clean boot. The
 // estimates vary by runtime and workload and are not additive.
@@ -134,6 +137,11 @@ var Categories = []Category{
 			"com.apple.itunescloudd",
 			"com.apple.itunesstored",
 			"com.apple.storekitd",
+			// Apple Media Services renders the in-app purchase payment
+			// sheet; these three are shared with the icloud category.
+			"com.apple.amsaccountsd",
+			"com.apple.amsengagementd",
+			"com.apple.amsondevicestoraged",
 			"com.apple.videosubscriptionsd",
 			"com.apple.assetsubscriptiond",
 			"com.apple.musicd",
@@ -378,19 +386,20 @@ type Profile struct {
 	Keep             map[string]bool // individual labels to leave enabled
 }
 
-// desired returns the labels this profile wants disabled.
+// desired returns the labels this profile wants disabled. Categories may share
+// labels, so a label stays enabled when any excepted category lists it.
 func (p Profile) Desired() map[string]bool {
-	set := make(map[string]bool)
+	set := SlimmableSet()
 	for _, c := range Categories {
-		if p.ExceptCategories[c.ID] {
+		if !p.ExceptCategories[c.ID] {
 			continue
 		}
 		for _, l := range c.Labels {
-			if p.Keep[l] {
-				continue
-			}
-			set[l] = true
+			delete(set, l)
 		}
+	}
+	for l := range p.Keep {
+		delete(set, l)
 	}
 	return set
 }

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -37,15 +37,42 @@ func TestManagedExcludesForbidden(t *testing.T) {
 	}
 }
 
-func TestNoDuplicateLabels(t *testing.T) {
-	seen := map[string]string{}
+// Labels may repeat across categories (a daemon can serve several features)
+// but never within one category.
+func TestNoDuplicateLabelsWithinCategory(t *testing.T) {
+	for _, c := range Categories {
+		seen := map[string]bool{}
+		for _, l := range c.Labels {
+			if seen[l] {
+				t.Errorf("label %q appears twice in category %q", l, c.ID)
+			}
+			seen[l] = true
+		}
+	}
+}
+
+func TestDesiredKeepsSharedLabelsOfExceptedCategories(t *testing.T) {
+	owners := map[string][]string{}
 	for _, c := range Categories {
 		for _, l := range c.Labels {
-			if prev, ok := seen[l]; ok {
-				t.Errorf("label %q appears in both %q and %q", l, prev, c.ID)
-			}
-			seen[l] = c.ID
+			owners[l] = append(owners[l], c.ID)
 		}
+	}
+	sharedSeen := false
+	for l, ids := range owners {
+		if len(ids) < 2 {
+			continue
+		}
+		sharedSeen = true
+		for _, id := range ids {
+			p := Profile{ExceptCategories: map[string]bool{id: true}, Keep: map[string]bool{}}
+			if p.Desired()[l] {
+				t.Errorf("--except %s should keep shared label %q enabled", id, l)
+			}
+		}
+	}
+	if !sharedSeen {
+		t.Error("expected at least one shared label (the AMS payment-sheet daemons)")
 	}
 }
 


### PR DESCRIPTION
## Problem

Reported by a user: slimming with `--except store` lets StoreKit load products, but attempting a purchase fails with:

```
AMSErrorDomain Code=10 "Payment Sheet Failed Presentation failed"
```

The buy request itself succeeds (`AMSStatusCode=200`, the server payload contains the fully-formed confirmation dialog) — what fails is presenting the sheet. The sheet is rendered by Apple Media Services (AMSUI), and the AMS daemons (`amsaccountsd`, `amsengagementd`, `amsondevicestoraged`) lived only in the `icloud` category, so `--except store` disabled them.

## Fix

**Categories may now overlap.** A label lives in every category whose feature needs it, and `Profile.Desired()` uses union semantics: a label stays enabled when **any** excepted category lists it (previously it was disabled if any non-excepted category listed it). The AMS trio joins `store` while remaining in `icloud`.

- `features.go`: the `storekit` doctor feature now checks `itunesstored` + the AMS daemons alongside `storekitd`, so `doctor --requires storekit` flags this state instead of passing it.
- `profiles_test.go`: duplicates are still forbidden *within* a category; a new test asserts every shared label is kept when either of its categories is excepted.
- GUI: `disabledDaemonCount` and per-service kept state are computed from a deduplicated effective set, so shared labels are neither double-counted nor shown disabled when another kept category keeps them.

## Verification

- `make check` passes (Go tests, vet, swift-format strict, script/plist lint)
- `make app` builds cleanly
- `simslim profiles store` shows the 12 daemons incl. the AMS trio; `doctor --list` shows the expanded `storekit` feature

## Caveats

- `store`'s `ApproxMemoryMB` (80) predates the three added daemons and may want re-measuring.
- The AMS diagnosis is inferred from the error domain, not empirically bisected; a real IAP test on a slimmed simulator would confirm the minimal set (and whether `akd` matters too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)