### PR TITLE
add a verify command: exact profile match check with drift listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ simslim profiles <id>    # the daemons in one category
 simslim on <udid>        # slim a simulator and reboot it slim
 simslim off <udid>       # put it back to stock
 simslim status <udid>    # how slim a booted simulator is
+simslim verify <udid> --profile ci.json   # exact profile match; non-zero on drift
 simslim doctor <udid> --requires push,storekit,universal-links
 simslim measure <udid>   # a booted simulator's memory footprint
 simslim top              # live fleet monitor; enter a sim for per-daemon RAM/CPU
@@ -192,6 +193,25 @@ Feature IDs are finer-grained than the slimming categories: each maps to just
 the daemons that back one capability. Run `simslim doctor --list` to see them
 all. Both the check and the list support `--json`.
 
+### Verifying a profile still holds
+
+The disable overrides are per-simulator state that is easy to lose without
+noticing: a `clone` comes up stock, so does a deleted-and-recreated device or a
+simulator from a new runtime, and nothing else fails loudly when that happens
+— the simulator just quietly runs heavy again. `verify` compares a booted
+simulator's overrides against a profile — the same `--profile`/`--except`/`--keep`
+you passed to `on` — and exits non-zero listing the drift, so a script or CI
+step can catch it and re-run `simslim on` (idempotent: it only applies the
+missing delta) to repair:
+
+```sh
+simslim verify <udid> --profile ci.json || simslim on <udid> --profile ci.json
+```
+
+Where `doctor` answers "do the features my tests need still work?", `verify`
+answers "is this simulator in exactly the slim state I configured?". Supports
+`--json`.
+
 ## Use as a Go library
 
 The repo root is an importable package with no external dependencies, so you can
@@ -245,7 +265,7 @@ CLI uses. macOS only, since everything runs through `xcrun simctl`.
 
 `simslim on` writes persistent `launchctl disable` entries for the chosen daemons into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only daemons that are safe to disable. Core workflow services such as `sharingd`, plus the handful that wedge a simulator when turned off, are left running.
 
-This is per-simulator state, not a global setting. The daemon disables live in that one simulator's launchd database and nowhere else. `simslim clone` does not carry them over: a clone comes up stock and has to be slimmed again with `simslim on`. The same goes for `erase`, `delete` and recreate, or "Erase All Content and Settings", so after any of those the simulator's memory climbs back to stock until you rerun `simslim on`. A simulator created from a new or updated runtime also starts stock. Copying the simulator's device directory does keep the disables, so a tar or a filesystem snapshot (how CI images are usually built) restores a slim simulator as slim. Run `simslim list` to see which simulators are currently slim.
+This is per-simulator state, not a global setting. The daemon disables live in that one simulator's launchd database and nowhere else. `simslim clone` does not carry them over: a clone comes up stock and has to be slimmed again with `simslim on`. The same goes for `erase`, `delete` and recreate, or "Erase All Content and Settings", so after any of those the simulator's memory climbs back to stock until you rerun `simslim on`. A simulator created from a new or updated runtime also starts stock. Copying the simulator's device directory does keep the disables, so a tar or a filesystem snapshot (how CI images are usually built) restores a slim simulator as slim. Run `simslim list` to see which simulators are currently slim, or `simslim verify` to check one against a specific profile.
 
 ## What you lose
 

--- a/cmd/simslim/app.go
+++ b/cmd/simslim/app.go
@@ -27,6 +27,12 @@ func newApp() *cli.Command {
 		{Name: "profiles", Flags: []cli.Flag{jsonFlag()}, Action: cmdProfiles},
 		{Name: "profile", Action: cmdNewProfile},
 		{Name: "status", Flags: []cli.Flag{jsonFlag(), &cli.BoolFlag{Name: "dropped", Usage: "list the disabled daemons grouped by category"}}, Action: cmdStatus},
+		{Name: "verify", Flags: []cli.Flag{
+			jsonFlag(),
+			&cli.StringFlag{Name: "profile", Usage: "verify against a JSON profile file (mutually exclusive with --except/--keep)"},
+			&cli.StringFlag{Name: "except", Usage: "comma-separated category IDs the profile leaves fully enabled (see `simslim profiles`)"},
+			&cli.StringFlag{Name: "keep", Usage: "comma-separated launchd labels the profile keeps running"},
+		}, Action: cmdVerify},
 		{Name: "doctor", Flags: []cli.Flag{
 			jsonFlag(),
 			&cli.StringFlag{Name: "requires", Usage: "comma-separated feature IDs the simulator must support (see `simslim doctor --list`)"},

--- a/cmd/simslim/main.go
+++ b/cmd/simslim/main.go
@@ -265,6 +265,42 @@ func cmdStatus(ctx context.Context, cmd *cli.Command) error {
 	return nil
 }
 
+func cmdVerify(ctx context.Context, cmd *cli.Command) error {
+	jsonOutput := cmd.Bool("json")
+	udid, err := oneUDID(cmd.Args().Slice())
+	if err != nil {
+		return err
+	}
+	p, err := simslim.BuildProfile(cmd.String("profile"), cmd.String("except"), cmd.String("keep"))
+	if err != nil {
+		return err
+	}
+	r, err := simslim.VerifyProfile(ctx, udid, p)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		if err := writeJSON(r); err != nil {
+			return err
+		}
+	} else if r.OK {
+		fmt.Printf("%s matches the profile: all %d expected daemons disabled.\n", udid, len(p.Desired()))
+	} else {
+		fmt.Printf("%s does not match the profile (%d missing, %d extra):\n", udid, len(r.Missing), len(r.Extra))
+		for _, l := range r.Missing {
+			fmt.Printf("  missing %s (should be disabled, is enabled)\n", l)
+		}
+		for _, l := range r.Extra {
+			fmt.Printf("  extra   %s (disabled beyond the profile)\n", l)
+		}
+		fmt.Println("Re-run `simslim on` with the same profile to repair.")
+	}
+	if !r.OK {
+		os.Exit(1)
+	}
+	return nil
+}
+
 func cmdDoctor(ctx context.Context, cmd *cli.Command) error {
 	jsonOutput := cmd.Bool("json")
 	if cmd.Bool("list") {
@@ -857,6 +893,14 @@ COMMANDS
                        Return an initially shutdown simulator to shutdown
   status <udid>        Report how slim a booted simulator is
       --dropped        Also list the disabled daemons grouped by category
+  verify <udid>        Check that a booted simulator's disable overrides still
+                       match a profile exactly; exits non-zero and lists the
+                       drift otherwise. Catches a silently stock simulator (a
+                       clone, or a recreated device); re-run ` + "`on`" + ` to repair
+      --profile path   Verify against a committed JSON profile; mutually
+                       exclusive with --except/--keep
+      --except ids     The profile's enabled categories (comma-separated)
+      --keep labels    The profile's kept daemons (comma-separated)
   doctor <udid>        Check required features against a booted simulator;
                        exits non-zero if slimming has broken any of them
       --requires ids   Comma-separated feature IDs to verify

--- a/verify.go
+++ b/verify.go
@@ -1,0 +1,59 @@
+package simslim
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// VerifyResult reports how a booted simulator's launchd disable overrides
+// compare to a profile's desired set. Only managed labels are considered.
+type VerifyResult struct {
+	UDID    string   `json:"udid"`
+	OK      bool     `json:"ok"`
+	Missing []string `json:"missing,omitempty"` // profile wants these disabled; they are enabled
+	Extra   []string `json:"extra,omitempty"`   // managed labels disabled beyond the profile
+}
+
+// VerifyProfile checks, without mutating anything, that a booted simulator's
+// disable overrides match the profile exactly. The overrides are per-simulator
+// state that is easy to lose silently — a clone comes up stock, and so does a
+// deleted-and-recreated device — so VerifyProfile detects the drift and callers
+// can re-run `on` (which is idempotent) to repair it.
+func VerifyProfile(ctx context.Context, udid string, p Profile) (VerifyResult, error) {
+	d, err := FindDevice(ctx, udid, "")
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	if d.State != "Booted" {
+		return VerifyResult{}, fmt.Errorf("simulator must be booted to read its state (it is %s)", d.State)
+	}
+	disabled, err := readDisabled(ctx, d.Set, d.UDID)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	r := compareDisabled(disabled, p.Desired(), managedSet())
+	r.UDID = udid
+	return r, nil
+}
+
+// compareDisabled diffs the currently disabled labels against the desired set,
+// restricted to the managed universe (unmanaged labels are never simslim's
+// business and never count as drift).
+func compareDisabled(disabled, desired, managed map[string]bool) VerifyResult {
+	var r VerifyResult
+	for l := range desired {
+		if !disabled[l] {
+			r.Missing = append(r.Missing, l)
+		}
+	}
+	for l := range disabled {
+		if managed[l] && !desired[l] {
+			r.Extra = append(r.Extra, l)
+		}
+	}
+	sort.Strings(r.Missing)
+	sort.Strings(r.Extra)
+	r.OK = len(r.Missing) == 0 && len(r.Extra) == 0
+	return r
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,64 @@
+package simslim
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCompareDisabled(t *testing.T) {
+	managed := map[string]bool{"a": true, "b": true, "c": true, "d": true}
+	tests := []struct {
+		name     string
+		disabled map[string]bool
+		desired  map[string]bool
+		want     VerifyResult
+	}{
+		{
+			name:     "exact match",
+			disabled: map[string]bool{"a": true, "b": true},
+			desired:  map[string]bool{"a": true, "b": true},
+			want:     VerifyResult{OK: true},
+		},
+		{
+			name:     "erase wiped everything",
+			disabled: map[string]bool{},
+			desired:  map[string]bool{"a": true, "b": true},
+			want:     VerifyResult{Missing: []string{"a", "b"}},
+		},
+		{
+			name:     "partial drift both directions",
+			disabled: map[string]bool{"a": true, "c": true},
+			desired:  map[string]bool{"a": true, "b": true},
+			want:     VerifyResult{Missing: []string{"b"}, Extra: []string{"c"}},
+		},
+		{
+			name:     "unmanaged disabled labels are not drift",
+			disabled: map[string]bool{"a": true, "com.example.other": true},
+			desired:  map[string]bool{"a": true},
+			want:     VerifyResult{OK: true},
+		},
+		{
+			name:     "stock device with empty profile",
+			disabled: map[string]bool{},
+			desired:  map[string]bool{},
+			want:     VerifyResult{OK: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareDisabled(tt.disabled, tt.desired, managed)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("compareDisabled() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareDisabledMissingSorted(t *testing.T) {
+	managed := map[string]bool{"z": true, "a": true, "m": true}
+	got := compareDisabled(map[string]bool{}, map[string]bool{"z": true, "a": true, "m": true}, managed)
+	want := []string{"a", "m", "z"}
+	if !reflect.DeepEqual(got.Missing, want) {
+		t.Errorf("Missing = %v, want %v", got.Missing, want)
+	}
+}


### PR DESCRIPTION
## Summary

A simulator can silently fall out of its configured slim state — a `clone` comes up stock (as the README documents), and so does a deleted-and-recreated device or one from a new runtime — and nothing fails loudly when that happens; the simulator just quietly runs heavy again. `status` reports a verdict against the whole managed universe, and `doctor` answers "do these features still work?", but neither answers "is this simulator in exactly the slim state my profile configured?".

`simslim verify <udid>` takes the same `--profile`/`--except`/`--keep` as `on`, compares the booted simulator's disable overrides against the profile's desired set (restricted to `managedSet()` — unmanaged labels never count as drift), prints the drift in both directions (`missing` = should be disabled but enabled, `extra` = managed disabled beyond the profile), and exits non-zero on any mismatch — so a script or CI preflight can gate on it and repair with the idempotent `on`:

```sh
simslim verify <udid> --profile ci.json || simslim on <udid> --profile ci.json
```

New library API in `verify.go`:

```go
type VerifyResult struct { UDID string; OK bool; Missing, Extra []string }
func VerifyProfile(ctx context.Context, udid string, p Profile) (VerifyResult, error)
```

Read-only (never mutates), requires a booted simulator (same constraint as `status`), supports `--json`, follows `doctor`'s exit-code pattern. The pure comparison (`compareDisabled`) is unit-tested; README gets a "Verifying a profile still holds" section.

Verified on an Apple Silicon Mac (Xcode 26.5, iPhone 17 / iOS 26.5 simulator): slimmed with a one-category profile → `verify` exit 0; `verify` against the full default profile → exit 1 listing 165 missing; cloned the slim simulator → `verify` on the clone → exit 1 listing exactly the 5 wiped labels; re-ran `on` ("Already slim"/delta-only) → exit 0.
