### PR TITLE
fail loudly when disable overrides do not survive the reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,11 @@ CLI uses. macOS only, since everything runs through `xcrun simctl`.
 
 `simslim on` writes persistent `launchctl disable` entries for the chosen daemons into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only daemons that are safe to disable. Core workflow services such as `sharingd`, plus the handful that wedge a simulator when turned off, are left running.
 
+Older runtimes do not persist launchd overrides across a reboot (observed on
+iOS 17): `launchctl` accepts each disable, but the simulator comes back stock.
+`simslim on` reads the state back after its reboot and fails with a clear error
+instead of claiming success, so slimming requires an iOS 18 or newer runtime.
+
 This is per-simulator state, not a global setting. The daemon disables live in that one simulator's launchd database and nowhere else. `simslim clone` does not carry them over: a clone comes up stock and has to be slimmed again with `simslim on`. The same goes for `erase`, `delete` and recreate, or "Erase All Content and Settings", so after any of those the simulator's memory climbs back to stock until you rerun `simslim on`. A simulator created from a new or updated runtime also starts stock. Copying the simulator's device directory does keep the disables, so a tar or a filesystem snapshot (how CI images are usually built) restores a slim simulator as slim. Run `simslim list` to see which simulators are currently slim.
 
 ## What you lose

--- a/slim.go
+++ b/slim.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
+	"strings"
 )
 
 // Reporter receives human-readable progress lines. A nil Reporter is a no-op,
@@ -51,7 +53,46 @@ func ensure(ctx context.Context, set, udid string, desired map[string]bool, repo
 	if err := WaitShutdown(ctx, set, udid, ShutdownTimeout); err != nil {
 		return true, err
 	}
-	return true, BootAndWait(ctx, set, udid)
+	if err := BootAndWait(ctx, set, udid); err != nil {
+		return true, err
+	}
+	after, err := readDisabled(ctx, set, udid)
+	if err != nil {
+		return true, err
+	}
+	if lost := countLost(after, desired, managedSet()); lost > 0 {
+		return true, persistError(ctx, udid, lost, len(toDisable)+len(toEnable))
+	}
+	return true, nil
+}
+
+// countLost reports how many of the desired managed transitions are not
+// reflected in the state read back after the reboot.
+func countLost(after, desired, managed map[string]bool) int {
+	toDisable, toEnable := delta(after, desired, managed)
+	return len(toDisable) + len(toEnable)
+}
+
+// persistError explains that launchctl accepted the transitions but the
+// overrides were gone after the reboot. Older runtimes (observed on iOS 17)
+// do not persist launchd disable overrides across a reboot, so slimming
+// silently has no effect there; failing loudly beats claiming success.
+func persistError(ctx context.Context, udid string, lost, applied int) error {
+	msg := fmt.Sprintf("the disable overrides did not survive the reboot (%d of %d changes lost)", lost, applied)
+	if d, err := FindDevice(ctx, udid, ""); err == nil && osMajor(d.OSVersion) > 0 && osMajor(d.OSVersion) < 18 {
+		msg += fmt.Sprintf("; iOS %s runtimes do not persist launchd overrides — use an iOS 18 or newer runtime", d.OSVersion)
+	}
+	return fmt.Errorf("%s", msg)
+}
+
+// osMajor extracts the major version from an OSVersion like "17.2" (0 when unknown).
+func osMajor(v string) int {
+	major, _, _ := strings.Cut(v, ".")
+	n, err := strconv.Atoi(major)
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // enableSlim disables the profile's daemons and boots the device slim.

--- a/slim_persist_test.go
+++ b/slim_persist_test.go
@@ -1,0 +1,41 @@
+package simslim
+
+import "testing"
+
+func TestCountLost(t *testing.T) {
+	managed := map[string]bool{"a": true, "b": true, "c": true}
+	tests := []struct {
+		name    string
+		after   map[string]bool
+		desired map[string]bool
+		want    int
+	}{
+		{"all persisted", map[string]bool{"a": true, "b": true}, map[string]bool{"a": true, "b": true}, 0},
+		{"nothing persisted", map[string]bool{}, map[string]bool{"a": true, "b": true}, 2},
+		{"partially persisted", map[string]bool{"a": true}, map[string]bool{"a": true, "b": true}, 1},
+		{"stale disable not re-enabled", map[string]bool{"a": true, "c": true}, map[string]bool{"a": true}, 1},
+		{"unmanaged labels ignored", map[string]bool{"a": true, "com.example.x": true}, map[string]bool{"a": true}, 0},
+		{"stock desired and reached", map[string]bool{}, map[string]bool{}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countLost(tt.after, tt.desired, managed); got != tt.want {
+				t.Errorf("countLost() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOSMajor(t *testing.T) {
+	tests := []struct {
+		v    string
+		want int
+	}{
+		{"17.2", 17}, {"18.5", 18}, {"26.5", 26}, {"18", 18}, {"", 0}, {"garbage", 0},
+	}
+	for _, tt := range tests {
+		if got := osMajor(tt.v); got != tt.want {
+			t.Errorf("osMajor(%q) = %d, want %d", tt.v, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

On older runtimes, slimming silently does nothing: `launchctl disable` accepts every transition and `simslim on` reports "Done. Simulator reconfigured and rebooted slim." — but the overrides are gone after the reboot and the simulator comes back fully stock. Reproduced on iOS 17.2 (Xcode 26.6 host): `on` exits 0 claiming 5/5 services updated, then `launchctl print-disabled system` shows "(no disabled services)" and `status` shows `0/170 managed daemons disabled (stock)`. iOS 18.5 on the same host persists correctly. A tool that claims success while doing nothing is worse than one that fails.

Fix: `ensure()` now reads the disabled state back after its reboot and fails when the applied transitions didn't stick:

```go
after, err := readDisabled(ctx, set, udid)
...
if lost := countLost(after, desired, managedSet()); lost > 0 {   // delta(after, desired, managedSet())
    return true, persistError(ctx, udid, lost, applied)
}
```

```
simslim: the disable overrides did not survive the reboot (5 of 5 changes lost); iOS 17.2 runtimes do not persist launchd overrides — use an iOS 18 or newer runtime
```

The version hint is only appended for runtimes with major < 18; on newer runtimes any persistence loss still fails, just without blaming the runtime. The check is scoped to `managedSet()` like everything else, covers both directions (a lost disable and a lost re-enable), and adds no work in the common path — it reuses the read that `ensure` already knows how to do, after the reboot that already happens. No JSON contract changes.

Verified end-to-end on an Intel Mac (Xcode 26.6): iPhone 15 / iOS 17.2 → exit 1 with the message above; iPhone 15 / iOS 18.5 → `on` and `off` both pass the read-back and exit 0. `countLost`/`osMajor` are unit-tested; README gets a note under "How it works".
