### PR TITLE
fix: keep Wallet daemons enabled with --except store so the payment sheet presents

### DIFF
--- a/features.go
+++ b/features.go
@@ -14,14 +14,18 @@ type Feature struct {
 // Features maps commonly required capabilities to the daemons they need running.
 var Features = []Feature{
 	{ID: "push", Name: "Push notifications", Labels: []string{"com.apple.apsd"}},
-	// In-app purchase needs the store daemons plus AMS, which presents the
-	// payment sheet — products load without AMS but purchases fail.
+	// In-app purchase needs the store daemons plus AMS, which runs the
+	// payment sheet task, plus Wallet (passd) which hosts the sheet UI and
+	// Finance (financed) which passd requires — products load without them
+	// but purchases fail at sheet presentation.
 	{ID: "storekit", Name: "StoreKit / in-app purchase", Labels: []string{
 		"com.apple.storekitd",
 		"com.apple.itunesstored",
 		"com.apple.amsaccountsd",
 		"com.apple.amsengagementd",
 		"com.apple.amsondevicestoraged",
+		"com.apple.passd",
+		"com.apple.financed",
 	}},
 	{ID: "app-store", Name: "App Store", Labels: []string{"com.apple.appstored", "com.apple.itunesstored"}},
 	{ID: "universal-links", Name: "Universal links / associated domains", Labels: []string{"com.apple.swcd"}},

--- a/profiles.go
+++ b/profiles.go
@@ -142,6 +142,10 @@ var Categories = []Category{
 			"com.apple.amsaccountsd",
 			"com.apple.amsengagementd",
 			"com.apple.amsondevicestoraged",
+			// Wallet hosts the payment authorization sheet and needs the
+			// Finance datastore; both shared with the other category.
+			"com.apple.passd",
+			"com.apple.financed",
 			"com.apple.videosubscriptionsd",
 			"com.apple.assetsubscriptiond",
 			"com.apple.musicd",


### PR DESCRIPTION
## Summary

#22 kept the AMS daemons alive with `--except store`, which was necessary but not sufficient: on v0.6.0 an in-app purchase on a slimmed simulator still fails at sheet presentation — the exact repro from #21. The AMS payment sheet task starts inside storekitd but dies with `AMSErrorDomain code=10` at `presentationWindowForPaymentAuthorizationController`, because the sheet UI is hosted by **Wallet** (`com.apple.passd`, via PassbookUIService) and passd requires the **Finance** datastore (`com.apple.financed`) — both of which live in the `other` category and stay disabled.

This adds `com.apple.passd` and `com.apple.financed` to the `store` category as shared labels (the category-overlap mechanism from #22) and to the `storekit` doctor feature, so `simslim doctor --requires storekit` now catches this exact failure.

## Verification (iPhone 16 / iOS 26.2 simulator, StoreKit-config test app driving a real `Product.purchase()`)

| State | Result |
|---|---|
| Stock | Sheet presents, purchase completes |
| `--except store` on v0.6.0 | `purchase()` throws in ~1s; log: `AMSPaymentSheetTask … Completed with error: AMSErrorDomain code=10`, "Unable to continue the purchase" (= issue #21) |
| + `passd` enabled manually | Still fails; passd loops on `com.apple.financed.service.coredatastore … No such process` |
| + `passd` + `financed` | **Payment sheet renders** (Coins / $0.99 / Purchase) and the flow proceeds |
| This branch, `simslim on --except store` + `verify` | Exact profile match, both Wallet daemons enabled |

Note: iOS 26.5 could not be used for the probe — a known Xcode 26.6 bug prevents `xcodebuild` CLI from delivering StoreKit configurations to storekitd on that runtime (works in the IDE only).

`ApproxMemoryMB` for `store` was not re-measured; keeping passd+financed adds a modest amount to the kept footprint.

Fixes #21.