### PR TITLE
fix: fail closed on non-persistent iOS runtimes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,12 +66,12 @@ each feature (push, storekit, universal-links, …) names just the daemons one
 testable capability needs. `doctor` reads a booted simulator's disabled labels
 and reports any required feature whose daemons are down, exiting non-zero — a CI
 preflight. `features_test.go` asserts every feature label is slimmable.
-`slim.go`'s `ensure()` boots the device, reads its currently
-disabled labels, computes a `delta` against the desired set, and applies the
-changes with `launchctl disable/enable` run inside the simulator via
-`simctl spawn`. The disables are written as persistent launchd overrides, so a
-slimmed simulator comes up slim on every subsequent boot in one boot. `on`
-disables the profile; `off` re-enables the whole managed set back to stock.
+`slim.go`'s `ensure()` rejects a non-empty slim profile on runtimes older than
+iOS 18.5 before booting or mutating the device, then reads the currently disabled
+labels, computes a `delta` against the desired set, and applies the changes with
+`launchctl disable/enable` run inside the simulator via `simctl spawn`. It reboots
+and reads the state back before reporting persistence. `on` disables the profile;
+`off` remains available on every runtime and re-enables the whole managed set.
 
 **simctl wrapper.** `simctl.go` is the only place that shells out to
 `xcrun simctl` (list/boot/shutdown/clone/erase/delete/spawn). `measure.go` sums

--- a/README.md
+++ b/README.md
@@ -293,10 +293,11 @@ CLI uses. macOS only, since everything runs through `xcrun simctl`.
 
 `simslim on` writes persistent `launchctl disable` entries for the chosen daemons into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only daemons that are safe to disable. Core workflow services such as `sharingd`, plus the handful that wedge a simulator when turned off, are left running.
 
-Older runtimes do not persist launchd overrides across a reboot (observed on
-iOS 17): `launchctl` accepts each disable, but the simulator comes back stock.
-`simslim on` reads the state back after its reboot and fails with a clear error
-instead of claiming success, so slimming requires an iOS 18 or newer runtime.
+The earliest runtime with verified persistence is iOS 18.5. iOS 17.x and 18.3
+accept each `launchctl disable`, but the simulator comes back stock after a
+reboot. `simslim on` rejects runtimes older than 18.5 before booting or changing
+launchd state. Supported runtimes are still read back after the reboot, and the
+command fails instead of claiming success if any requested override was lost.
 
 This is per-simulator state, not a global setting. The daemon disables live in
 that one simulator's launchd database and nowhere else. `simslim clone` copies

--- a/slim.go
+++ b/slim.go
@@ -21,10 +21,19 @@ func (r Reporter) report(msg string) {
 // ensure brings the device to exactly the desired disabled state and boots it.
 // The disabled overrides persist in the device's launchd DB, so once set a slim
 // device comes up slim in a single boot; a reboot only happens when the state
-// actually changes. A running device is required to read/mutate launchctl, so
-// the device is booted first regardless. Each slow phase reports progress so the
-// caller can show the user that a multi-minute reconfigure is still working.
+// actually changes. A non-empty profile is rejected before boot on runtimes
+// without persistent overrides. Each slow phase reports progress so the caller
+// can show the user that a multi-minute reconfigure is still working.
 func ensure(ctx context.Context, set, udid string, desired map[string]bool, report Reporter) (changed bool, err error) {
+	if len(desired) > 0 {
+		d, err := FindDevice(ctx, udid, set)
+		if err != nil {
+			return false, err
+		}
+		if !persistentOverridesSupported(d.OSVersion) {
+			return false, fmt.Errorf("iOS %s runtime cannot persist launchd disable overrides across reboot; simslim requires iOS 18.5 or newer", d.OSVersion)
+		}
+	}
 	report.report("Booting the simulator (a first boot can take up to a minute)...")
 	if err := BootAndWait(ctx, set, udid); err != nil {
 		return false, err
@@ -61,7 +70,7 @@ func ensure(ctx context.Context, set, udid string, desired map[string]bool, repo
 		return true, err
 	}
 	if lost := countLost(after, desired, managedSet()); lost > 0 {
-		return true, persistError(ctx, udid, lost, len(toDisable)+len(toEnable))
+		return true, fmt.Errorf("the disable overrides did not survive the reboot (%d of %d changes lost)", lost, len(toDisable)+len(toEnable))
 	}
 	return true, nil
 }
@@ -73,26 +82,14 @@ func countLost(after, desired, managed map[string]bool) int {
 	return len(toDisable) + len(toEnable)
 }
 
-// persistError explains that launchctl accepted the transitions but the
-// overrides were gone after the reboot. Older runtimes (observed on iOS 17)
-// do not persist launchd disable overrides across a reboot, so slimming
-// silently has no effect there; failing loudly beats claiming success.
-func persistError(ctx context.Context, udid string, lost, applied int) error {
-	msg := fmt.Sprintf("the disable overrides did not survive the reboot (%d of %d changes lost)", lost, applied)
-	if d, err := FindDevice(ctx, udid, ""); err == nil && osMajor(d.OSVersion) > 0 && osMajor(d.OSVersion) < 18 {
-		msg += fmt.Sprintf("; iOS %s runtimes do not persist launchd overrides — use an iOS 18 or newer runtime", d.OSVersion)
+func persistentOverridesSupported(version string) bool {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return false
 	}
-	return fmt.Errorf("%s", msg)
-}
-
-// osMajor extracts the major version from an OSVersion like "17.2" (0 when unknown).
-func osMajor(v string) int {
-	major, _, _ := strings.Cut(v, ".")
-	n, err := strconv.Atoi(major)
-	if err != nil {
-		return 0
-	}
-	return n
+	major, majorErr := strconv.Atoi(parts[0])
+	minor, minorErr := strconv.Atoi(parts[1])
+	return majorErr == nil && minorErr == nil && (major > 18 || major == 18 && minor >= 5)
 }
 
 // enableSlim disables the profile's daemons and boots the device slim.

--- a/slim_persist_test.go
+++ b/slim_persist_test.go
@@ -1,6 +1,52 @@
 package simslim
 
-import "testing"
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureRejectsIOS183BeforeBoot(t *testing.T) {
+	const udid = "00000000-0000-0000-0000-000000000034"
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "xcrun.log")
+	xcrunPath := filepath.Join(dir, "xcrun")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$SIMSLIM_XCRUN_LOG"
+if [ "$*" = "simctl list devices -j" ]; then
+  printf '%s\n' '{"devices":{"com.apple.CoreSimulator.SimRuntime.iOS-18-3":[{"udid":"00000000-0000-0000-0000-000000000034","name":"Issue 34","state":"Shutdown","isAvailable":true,"dataPath":"/tmp/issue-34"}]}}'
+  exit 0
+fi
+exit 99
+`
+	if err := os.WriteFile(xcrunPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("SIMSLIM_XCRUN_LOG", logPath)
+
+	var label string
+	for label = range SlimmableSet() {
+		break
+	}
+	changed, err := ensure(context.Background(), "default", udid, map[string]bool{label: true}, nil)
+	if changed {
+		t.Fatal("ensure reported a change on an unsupported runtime")
+	}
+	const want = "iOS 18.3 runtime cannot persist launchd disable overrides across reboot; simslim requires iOS 18.5 or newer"
+	if err == nil || err.Error() != want {
+		t.Fatalf("ensure error = %v, want %q", err, want)
+	}
+	log, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if got := strings.TrimSpace(string(log)); got != "simctl list devices -j" {
+		t.Fatalf("xcrun calls = %q, want only the read-only device lookup", got)
+	}
+}
 
 func TestCountLost(t *testing.T) {
 	managed := map[string]bool{"a": true, "b": true, "c": true}
@@ -26,16 +72,24 @@ func TestCountLost(t *testing.T) {
 	}
 }
 
-func TestOSMajor(t *testing.T) {
+func TestPersistentOverridesSupported(t *testing.T) {
 	tests := []struct {
 		v    string
-		want int
+		want bool
 	}{
-		{"17.2", 17}, {"18.5", 18}, {"26.5", 26}, {"18", 18}, {"", 0}, {"garbage", 0},
+		{"17.5", false},
+		{"18.3", false},
+		{"18.4.1", false},
+		{"18.5", true},
+		{"18.5.1", true},
+		{"26.5", true},
+		{"18", false},
+		{"", false},
+		{"garbage", false},
 	}
 	for _, tt := range tests {
-		if got := osMajor(tt.v); got != tt.want {
-			t.Errorf("osMajor(%q) = %d, want %d", tt.v, got, tt.want)
+		if got := persistentOverridesSupported(tt.v); got != tt.want {
+			t.Errorf("persistentOverridesSupported(%q) = %t, want %t", tt.v, got, tt.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Reject non-empty slim profiles on iOS runtimes older than 18.5 before booting or mutating the simulator.
- Keep `off` available on every runtime and retain the post-reboot read-back gate on supported runtimes.
- Document the evidence-backed runtime floor without changing JSON or public API contracts.

## Root cause

`launchctl disable` updates live launchd bookkeeping on iOS 17.x and 18.3, but those runtimes discard all overrides at reboot. The existing guard used only a major-version boundary and therefore treated every iOS 18 runtime as supported. The earliest runtime with repository runtime evidence for persistence is iOS 18.5, so this change fails closed below that boundary instead of claiming a filesystem or launchd repair that has not been proven.

## Tests

- `gofmt` clean for all Go files
- `go test ./...`
- `go vet ./...`
- `make check`
- Deterministic fake-`xcrun` regression: iOS 18.3 performs only `simctl list devices -j`; no boot, spawn, shutdown, or launchctl mutation occurs.
- Version matrix covers iOS 17.5, 18.3, 18.4.1, 18.5, 18.5.1, and 26.5.

## Runtime validation

HOLD: no real Simulator reproduction was performed because the host was already known not to satisfy the required memory, swap, workload, and disposable-device preflight. No simulator was booted or mutated.

Fixes #34