### PR TITLE
fix: clarify slimming status and memory accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ One simulator, booted stock and then slimmed, same device and settle time (M1 Pr
 
 Memory here is phys_footprint, the figure Activity Monitor shows, which counts compressed and swapped pages. That's what decides how many simulators fit before the machine starts swapping. Run `simslim measure <udid>` to see it for any booted simulator.
 
+`status` and `measure` answer different questions. `status` counts only the
+allowlisted launchd labels SimSlim manages; it is not a live-process count. A
+slim boot still runs required core services plus system apps and extensions.
+`measure` walks every process under that simulator's `launchd_sim` and sums
+`phys_footprint`. A sum of `ps` RSS values is not comparable because RSS counts
+shared mappings once for every process that maps them.
+
 ## Install
 
 ```sh
@@ -59,10 +66,10 @@ service or disk changes so the copy can serve as a backup.
 ```sh
 simslim list             # simulators and their slim status (--booted to filter)
 simslim profiles         # what a slim boot turns off
-simslim profiles <id>    # the daemons in one category
+simslim profiles <id>    # the launchd labels in one category
 simslim on <udid>        # slim a simulator and reboot it slim
 simslim off <udid>       # put it back to stock
-simslim status <udid>    # how slim a booted simulator is
+simslim status <udid>    # managed launchd-label state (not a process count)
 simslim verify <udid> --profile ci.json   # exact profile match; non-zero on drift
 simslim doctor <udid> --requires push,storekit,universal-links
 simslim measure <udid>   # a booted simulator's memory footprint
@@ -291,7 +298,7 @@ CLI uses. macOS only, since everything runs through `xcrun simctl`.
 
 ## How it works
 
-`simslim on` writes persistent `launchctl disable` entries for the chosen daemons into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only daemons that are safe to disable. Core workflow services such as `sharingd`, plus the handful that wedge a simulator when turned off, are left running.
+`simslim on` writes persistent `launchctl disable` entries for the chosen launchd labels into the simulator's own launchd database, then reboots it. The entries stick across reboots, so the simulator comes up slim in a single boot from then on. `simslim off` clears them and reboots back to stock. Your Mac is never touched, only the simulator you point it at, and only services that are safe to disable. Core workflow services such as `sharingd`, plus the handful that wedge a simulator when turned off, are left running.
 
 Older runtimes do not persist launchd overrides across a reboot (observed on
 iOS 17): `launchctl` accepts each disable, but the simulator comes back stock.

--- a/cmd/simslim/app.go
+++ b/cmd/simslim/app.go
@@ -26,7 +26,7 @@ func newApp() *cli.Command {
 		{Name: "list", Flags: []cli.Flag{jsonFlag(), &cli.BoolFlag{Name: "booted", Usage: "only list booted simulators"}}, Action: cmdList},
 		{Name: "profiles", Flags: []cli.Flag{jsonFlag()}, Action: cmdProfiles},
 		{Name: "profile", Action: cmdNewProfile},
-		{Name: "status", Flags: []cli.Flag{jsonFlag(), &cli.BoolFlag{Name: "dropped", Usage: "list the disabled daemons grouped by category"}}, Action: cmdStatus},
+		{Name: "status", Flags: []cli.Flag{jsonFlag(), &cli.BoolFlag{Name: "dropped", Usage: "list the disabled launchd labels grouped by category"}}, Action: cmdStatus},
 		{Name: "verify", Flags: []cli.Flag{
 			jsonFlag(),
 			&cli.StringFlag{Name: "profile", Usage: "verify against a JSON profile file (mutually exclusive with --except/--keep)"},

--- a/cmd/simslim/main.go
+++ b/cmd/simslim/main.go
@@ -250,10 +250,10 @@ func cmdStatus(ctx context.Context, cmd *cli.Command) error {
 	if jsonOutput {
 		return writeJSON(simslim.StatusOutput{Status: st, Verdict: verdict, Dropped: dropped})
 	}
-	fmt.Printf("%s: %d/%d managed daemons disabled (%s)\n", udid, st.ManagedDisabled, st.ManagedTotal, verdict)
+	fmt.Printf("%s: %d/%d managed launchd labels disabled (%s)\n", udid, st.ManagedDisabled, st.ManagedTotal, verdict)
 	if showDropped {
 		if len(dropped) == 0 {
-			fmt.Println("  Nothing dropped; every managed daemon is enabled.")
+			fmt.Println("  Nothing dropped; every managed launchd label is enabled.")
 		}
 		for _, c := range dropped {
 			fmt.Printf("  %-14s %s — %s\n", c.ID, c.Name, c.Downside)
@@ -374,7 +374,7 @@ func cmdMeasure(ctx context.Context, cmd *cli.Command) error {
 	if jsonOutput {
 		return writeJSON(m)
 	}
-	fmt.Printf("%s: %d processes, %s memory footprint\n", udid, m.Processes, humanBytes(m.Bytes))
+	fmt.Printf("%s: %d processes, %s memory footprint (phys_footprint)\n", udid, m.Processes, humanBytes(m.Bytes))
 	return nil
 }
 

--- a/measure_test.go
+++ b/measure_test.go
@@ -49,3 +49,17 @@ func TestParsePS(t *testing.T) {
 		t.Errorf("header row was parsed as a process")
 	}
 }
+
+func TestParseBytes(t *testing.T) {
+	tests := map[string]int64{
+		"512B":  512,
+		"8K":    8 << 10,
+		"823M":  823 << 20,
+		"1.5G+": 3 << 29,
+	}
+	for input, want := range tests {
+		if got := parseBytes(input); got != want {
+			t.Errorf("parseBytes(%q) = %d, want %d", input, got, want)
+		}
+	}
+}

--- a/output.go
+++ b/output.go
@@ -18,7 +18,7 @@ type StatusOutput struct {
 	Dropped []DroppedCategory `json:"dropped,omitempty"` // only when `status --dropped` is requested
 }
 
-// DroppedCategory lists the managed daemons a category has disabled on a
+// DroppedCategory lists the managed launchd labels a category has disabled on a
 // simulator, alongside the feature that stops working as a result.
 type DroppedCategory struct {
 	ID       string   `json:"id"`

--- a/profiles_test.go
+++ b/profiles_test.go
@@ -37,6 +37,26 @@ func TestManagedExcludesForbidden(t *testing.T) {
 	}
 }
 
+// These are the launchd or bundle identifiers behind the live processes cited
+// in issue #30. None is part of a full slim profile: required and unsafe
+// services stay up, and system apps/extensions are not managed launchd labels.
+func TestFullProfileDoesNotClaimUnmanagedProcesses(t *testing.T) {
+	desired := (Profile{}).Desired()
+	for _, label := range []string{
+		"com.apple.routined",
+		"com.apple.sharingd",
+		"com.apple.locationd",
+		"com.apple.eventkitsyncd",
+		"com.apple.Spotlight",
+		"com.apple.MercuryPoster",
+		"com.apple.texttospeech.SiriAUSP",
+	} {
+		if desired[label] {
+			t.Errorf("full profile claims live process %q is disabled", label)
+		}
+	}
+}
+
 // Labels may repeat across categories (a daemon can serve several features)
 // but never within one category.
 func TestNoDuplicateLabelsWithinCategory(t *testing.T) {


### PR DESCRIPTION
## Root cause

The report compares two different contracts:

- `status` counts the allowlisted launchd labels recorded as disabled. Static inspection of the installed iOS 26.5 (23F77) compiled launchd catalog found all 170 profile labels present, so there is no label-shift gap.
- Every cited live process maps to a service or bundle identifier outside the full slim profile. `routined` is safety-excluded, `sharingd` is deliberately always-on, and `locationd`, `eventkitsyncd`, Spotlight.app, MercuryPosterExtension, and SiriAUSP are not managed labels.
- `measure` recursively includes every process below the simulator `launchd_sim`, but sums `top` `phys_footprint`. Summing `ps` RSS is not comparable because shared mappings are counted again for each process.

The reported 71-process, 823 MB footprint is therefore consistent with the documented slim range; the cited processes and RSS total do not establish a runtime disable failure.

## Change

- describe status as managed launchd-label state, not a live-process count
- identify the CLI memory value as `phys_footprint`
- document why required processes remain and why a summed RSS tree disagrees
- add deterministic regressions for the cited unmanaged identifiers and memory-unit parsing
- leave JSON fields/tags and every simulator mutation path unchanged

## Validation

- `gofmt`
- `go test -count=1 ./...`
  - `github.com/mobai-app/simslim`: ok (0.621s)
  - `github.com/mobai-app/simslim/cmd/simslim`: ok (0.669s)
- `go vet ./...`
- `make check`
  - Go tests and vet passed
  - Swift format lint passed
  - build script syntax passed
  - `gui/Info.plist: OK`

Real Simulator reproduction is HOLD. Fresh preflight on Xcode 26.6 found only 752 MB unused RAM, 1.2 GiB free swap, two booted ProTips simulators, and unrelated Flutter/Codex/Crashlytics workloads. No simulator was created, booted, shut down, slimmed, cloned, erased, deleted, or otherwise mutated.

Closes #30