### PR TITLE
fix: surface xcrun stderr when simctl list fails

### DIFF
--- a/simctl.go
+++ b/simctl.go
@@ -3,6 +3,7 @@ package simslim
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
@@ -103,7 +104,7 @@ func xcrun(ctx context.Context, args ...string) ([]byte, error) {
 func listDevicesInSet(ctx context.Context, set deviceSetInfo) ([]Device, error) {
 	out, err := exec.CommandContext(ctx, "xcrun", simctlArgsForSet(set.token, "list", "devices", "-j")...).Output()
 	if err != nil {
-		return nil, fmt.Errorf("simctl list: %w", err)
+		return nil, listError(err)
 	}
 	var parsed struct {
 		Devices map[string][]struct {
@@ -130,6 +131,31 @@ func listDevicesInSet(ctx context.Context, set deviceSetInfo) ([]Device, error) 
 		}
 	}
 	return devices, nil
+}
+
+// listError surfaces xcrun's stderr, which Output (kept separate so stdout
+// stays clean JSON) parks in ExitError.Stderr; without it a failed listing
+// reports only an exit code.
+func listError(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return formatListError(err, string(exitErr.Stderr))
+	}
+	return fmt.Errorf("simctl list: %w", err)
+}
+
+// formatListError appends stderr to the listing error and, when xcrun cannot
+// find simctl at all — xcode-select pointing at the Command Line Tools, which
+// do not ship it — says how to select a full Xcode.
+func formatListError(err error, stderr string) error {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return fmt.Errorf("simctl list: %w", err)
+	}
+	if strings.Contains(stderr, `unable to find utility "simctl"`) {
+		return fmt.Errorf("simctl list: %w: %s (simctl ships with full Xcode, not the Command Line Tools; select one with `sudo xcode-select -s /Applications/Xcode.app`)", err, stderr)
+	}
+	return fmt.Errorf("simctl list: %w: %s", err, stderr)
 }
 
 // The default set is mandatory; a secondary set that cannot be listed (e.g. it

--- a/simctl_test.go
+++ b/simctl_test.go
@@ -1,6 +1,7 @@
 package simslim
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -57,6 +58,61 @@ func TestParseBatchOK(t *testing.T) {
 		if !got[label] {
 			t.Errorf("parseBatchOK() missing %q", label)
 		}
+	}
+}
+
+func TestFormatListError(t *testing.T) {
+	exit72 := errors.New("exit status 72")
+	tests := []struct {
+		name    string
+		stderr  string
+		want    []string
+		wantNot []string
+	}{
+		{
+			name:    "no stderr keeps the bare error",
+			stderr:  "",
+			want:    []string{"simctl list: exit status 72"},
+			wantNot: []string{"xcode-select"},
+		},
+		{
+			name:    "whitespace-only stderr keeps the bare error",
+			stderr:  "  \n",
+			want:    []string{"simctl list: exit status 72"},
+			wantNot: []string{"xcode-select"},
+		},
+		{
+			name:   "stderr is appended",
+			stderr: "An error was encountered processing the command\n",
+			want:   []string{"simctl list: exit status 72: An error was encountered processing the command"},
+		},
+		{
+			name:   "missing simctl adds the xcode-select hint",
+			stderr: `xcrun: error: unable to find utility "simctl", not a developer tool or in PATH`,
+			want: []string{
+				`unable to find utility "simctl"`,
+				"sudo xcode-select -s",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatListError(exit72, tt.stderr).Error()
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("formatListError() = %q, missing %q", got, want)
+				}
+			}
+			for _, wantNot := range tt.wantNot {
+				if strings.Contains(got, wantNot) {
+					t.Errorf("formatListError() = %q, should not contain %q", got, wantNot)
+				}
+			}
+			if !errors.Is(formatListError(exit72, tt.stderr), exit72) {
+				t.Errorf("formatListError() does not wrap the original error")
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

`listDevicesInSet` reads stdout with `.Output()` so the JSON stays clean, but on failure it wraps only the exit code, discarding the stderr that `exec.ExitError` already captured.

Every other simctl call in `simctl.go` (`boot`, `shutdown`, `rename`, …) uses `CombinedOutput()` and appends the output to its error. `list` is the one exception, and it's the first command most users run.

## Repro

On a Mac whose developer directory points at the Command Line Tools (which don't ship simctl):

```sh
sudo xcode-select -s /Library/Developer/CommandLineTools
simslim list
```

Before:

```text
simslim: simctl list: exit status 72
```

After:

```text
simslim: simctl list: exit status 72: xcrun: error: unable to find utility "simctl",
not a developer tool or in PATH (simctl ships with full Xcode, not the Command Line
Tools; select one with `sudo xcode-select -s /Applications/Xcode.app`)
```

## Change

* `listError` pulls stderr out of `exec.ExitError` and appends it, matching the file's existing `simctl <verb>: %w: <output>` style.
* When stderr shows xcrun can't find simctl at all, the error adds a one-line hint to select a full Xcode via `xcode-select`.
* `TestFormatListError`: pure table-driven unit test (no simulators booted), covering empty stderr, ordinary stderr, the missing-simctl hint, and `errors.Is` wrapping.
